### PR TITLE
Update notebook for better readability

### DIFF
--- a/notebooks/initial_EDA.ipynb
+++ b/notebooks/initial_EDA.ipynb
@@ -4,13 +4,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Inital EDA \n",
+    "# Initial EDA \n",
     "\n",
     "This is a short notebook to look at the available data provided and to see if we can determine which test failures appear to be correlated with each other. \n",
     "\n",
     "1. Load and rearrange our dataset\n",
     "2. Encode our data with a binary encoding scheme\n",
-    "3. Analize data looking for highly correlated failure sets\n",
+    "3. Analyze data looking for highly correlated failure sets\n",
     "4. Example: Given a test failure of interest return other test failures that are highly correlated.  \n"
    ]
   },
@@ -325,7 +325,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -345,7 +345,7 @@
        "Name: failedTestNames, Length: 102, dtype: object"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -360,9 +360,9 @@
    "source": [
     "### What is this data?\n",
     "\n",
-    "It looks like we have 102 ci job runs in our dataset. And for each job run we have list of tests that failed. Our goal here is to develop a method to determine which tests are highly correlated with eachother, or in otherwords, are likely to coocurr. \n",
+    "It looks like we have 102 ci job runs in our dataset. And for each job run we have list of tests that failed. Our goal here is to develop a method to determine which tests are highly correlated with each other, or in other words, are likely to cooccur. \n",
     "\n",
-    "So we want to evaluate the occurence of these tests over all 102 jobs availble to us in this dataset. In order to do this, we will encode each job as a vector, where each position represents 1 of the possible tests. Positions with 1 represent the test being present, otherwise it will be 0. This binary encoding scheme should simply our job.   "
+    "So we want to evaluate the occurrence of these tests over all 102 jobs available to us in this dataset. In order to do this, we will encode each job as a vector, where each position represents 1 of the possible tests. Positions with 1 represent the test being present, otherwise it will be 0. This binary encoding scheme should simply our job.   "
    ]
   },
   {
@@ -371,12 +371,12 @@
    "source": [
     "# Encoding\n",
     "\n",
-    "For our inital approach we are going to consider each test for each job as a feature that is either present (1) or absent (0). This should make comparing job results and test coocurances rather straightforward.   "
+    "For our initial approach we are going to consider each test for each job as a feature that is either present (1) or absent (0). This should make comparing job results and test cooccurrence rather straightforward.   "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -399,7 +399,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -415,7 +415,7 @@
        "1455"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -437,7 +437,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -446,7 +446,7 @@
        "1455"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -465,7 +465,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -481,7 +481,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -490,7 +490,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -510,13 +510,349 @@
        "Name: failedTestNames, Length: 102, dtype: object"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "encoded"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>[sig-apps][Feature:DeploymentConfig] deploymentconfigs adoption will orphan all RCs and adopt them back when recreated</th>\n",
+       "      <th>[sig-network][Feature:Router] The HAProxy router should expose prometheus metrics for a route</th>\n",
+       "      <th>[sig-builds][Feature:Builds][webhook] TestWebhookGitHubPing</th>\n",
+       "      <th>operator.Run template e2e-azure - e2e-azure container test</th>\n",
+       "      <th>[sig-builds][Feature:Builds] oc new-app  should succeed with an imagestream</th>\n",
+       "      <th>[sig-instrumentation][Late] Alerts should have a Watchdog alert in firing state the entire cluster run</th>\n",
+       "      <th>[sig-instrumentation][Late] Alerts shouldn't report any alerts in firing state apart from Watchdog and AlertmanagerReceiversNotConfigured</th>\n",
+       "      <th>[sig-cli] oc adm must-gather runs successfully</th>\n",
+       "      <th>[sig-builds][Feature:Builds] prune builds based on settings in the buildconfig  should prune errored builds based on the failedBuildsHistoryLimit setting</th>\n",
+       "      <th>[sig-instrumentation] Prometheus when installed on the cluster shouldn't report any alerts in firing state apart from Watchdog and AlertmanagerReceiversNotConfigured [Early]</th>\n",
+       "      <th>...</th>\n",
+       "      <th>[sig-storage] In-tree Volumes [Driver: emptydir] [Testpattern: Dynamic PV (block volmode)] volume-expand should not allow expansion of pvcs without AllowVolumeExpansion property</th>\n",
+       "      <th>[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link-bindmounted] [Testpattern: Pre-provisioned PV (ntfs)][sig-windows] volumes should allow exec of files on the volume</th>\n",
+       "      <th>[sig-storage] In-tree Volumes [Driver: emptydir] [Testpattern: Pre-provisioned PV (default fs)] subPath should support non-existent path</th>\n",
+       "      <th>[sig-storage] In-tree Volumes [Driver: gcepd] [Testpattern: Dynamic PV (default fs)] provisioning should provision storage with snapshot data source [Feature:VolumeSnapshotDataSource]</th>\n",
+       "      <th>operator.Run template e2e-aws-scaleup-rhel7 - e2e-aws-scaleup-rhel7 container test</th>\n",
+       "      <th>[sig-storage] In-tree Volumes [Driver: aws] [Testpattern: Dynamic PV (ext4)] volumes should allow exec of files on the volume</th>\n",
+       "      <th>[sig-storage] In-tree Volumes [Driver: cinder] [Testpattern: Dynamic PV (block volmode)] volume-expand should not allow expansion of pvcs without AllowVolumeExpansion property</th>\n",
+       "      <th>operator.Run template e2e-aws-serial - e2e-aws-serial container test</th>\n",
+       "      <th>[sig-storage] CSI Volumes [Driver: csi-hostpath] [Testpattern: Dynamic PV (filesystem volmode)] volumeLimits should support volume limits [Serial]</th>\n",
+       "      <th>[sig-storage] In-tree Volumes [Driver: azure-disk] [Testpattern: Inline-volume (default fs)] subPath should be able to unmount after the subpath directory is deleted</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 1455 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   [sig-apps][Feature:DeploymentConfig] deploymentconfigs adoption will orphan all RCs and adopt them back when recreated  \\\n",
+       "0                                                  1                                                                        \n",
+       "1                                                  1                                                                        \n",
+       "2                                                  1                                                                        \n",
+       "3                                                  1                                                                        \n",
+       "4                                                  1                                                                        \n",
+       "\n",
+       "   [sig-network][Feature:Router] The HAProxy router should expose prometheus metrics for a route  \\\n",
+       "0                                                  1                                               \n",
+       "1                                                  0                                               \n",
+       "2                                                  1                                               \n",
+       "3                                                  1                                               \n",
+       "4                                                  1                                               \n",
+       "\n",
+       "   [sig-builds][Feature:Builds][webhook] TestWebhookGitHubPing  \\\n",
+       "0                                                  1             \n",
+       "1                                                  1             \n",
+       "2                                                  1             \n",
+       "3                                                  0             \n",
+       "4                                                  1             \n",
+       "\n",
+       "   operator.Run template e2e-azure - e2e-azure container test  \\\n",
+       "0                                                  1            \n",
+       "1                                                  0            \n",
+       "2                                                  1            \n",
+       "3                                                  0            \n",
+       "4                                                  1            \n",
+       "\n",
+       "   [sig-builds][Feature:Builds] oc new-app  should succeed with an imagestream  \\\n",
+       "0                                                  1                             \n",
+       "1                                                  0                             \n",
+       "2                                                  1                             \n",
+       "3                                                  0                             \n",
+       "4                                                  1                             \n",
+       "\n",
+       "   [sig-instrumentation][Late] Alerts should have a Watchdog alert in firing state the entire cluster run  \\\n",
+       "0                                                  1                                                        \n",
+       "1                                                  0                                                        \n",
+       "2                                                  1                                                        \n",
+       "3                                                  1                                                        \n",
+       "4                                                  1                                                        \n",
+       "\n",
+       "   [sig-instrumentation][Late] Alerts shouldn't report any alerts in firing state apart from Watchdog and AlertmanagerReceiversNotConfigured  \\\n",
+       "0                                                  1                                                                                           \n",
+       "1                                                  0                                                                                           \n",
+       "2                                                  1                                                                                           \n",
+       "3                                                  1                                                                                           \n",
+       "4                                                  1                                                                                           \n",
+       "\n",
+       "   [sig-cli] oc adm must-gather runs successfully  \\\n",
+       "0                                               1   \n",
+       "1                                               1   \n",
+       "2                                               1   \n",
+       "3                                               0   \n",
+       "4                                               1   \n",
+       "\n",
+       "   [sig-builds][Feature:Builds] prune builds based on settings in the buildconfig  should prune errored builds based on the failedBuildsHistoryLimit setting  \\\n",
+       "0                                                  1                                                                                                           \n",
+       "1                                                  0                                                                                                           \n",
+       "2                                                  1                                                                                                           \n",
+       "3                                                  0                                                                                                           \n",
+       "4                                                  1                                                                                                           \n",
+       "\n",
+       "   [sig-instrumentation] Prometheus when installed on the cluster shouldn't report any alerts in firing state apart from Watchdog and AlertmanagerReceiversNotConfigured [Early]  \\\n",
+       "0                                                  1                                                                                                                               \n",
+       "1                                                  0                                                                                                                               \n",
+       "2                                                  0                                                                                                                               \n",
+       "3                                                  1                                                                                                                               \n",
+       "4                                                  0                                                                                                                               \n",
+       "\n",
+       "   ...  \\\n",
+       "0  ...   \n",
+       "1  ...   \n",
+       "2  ...   \n",
+       "3  ...   \n",
+       "4  ...   \n",
+       "\n",
+       "   [sig-storage] In-tree Volumes [Driver: emptydir] [Testpattern: Dynamic PV (block volmode)] volume-expand should not allow expansion of pvcs without AllowVolumeExpansion property  \\\n",
+       "0                                                  0                                                                                                                                   \n",
+       "1                                                  0                                                                                                                                   \n",
+       "2                                                  0                                                                                                                                   \n",
+       "3                                                  0                                                                                                                                   \n",
+       "4                                                  0                                                                                                                                   \n",
+       "\n",
+       "   [sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir-link-bindmounted] [Testpattern: Pre-provisioned PV (ntfs)][sig-windows] volumes should allow exec of files on the volume  \\\n",
+       "0                                                  0                                                                                                                                             \n",
+       "1                                                  0                                                                                                                                             \n",
+       "2                                                  0                                                                                                                                             \n",
+       "3                                                  0                                                                                                                                             \n",
+       "4                                                  0                                                                                                                                             \n",
+       "\n",
+       "   [sig-storage] In-tree Volumes [Driver: emptydir] [Testpattern: Pre-provisioned PV (default fs)] subPath should support non-existent path  \\\n",
+       "0                                                  0                                                                                          \n",
+       "1                                                  0                                                                                          \n",
+       "2                                                  0                                                                                          \n",
+       "3                                                  0                                                                                          \n",
+       "4                                                  0                                                                                          \n",
+       "\n",
+       "   [sig-storage] In-tree Volumes [Driver: gcepd] [Testpattern: Dynamic PV (default fs)] provisioning should provision storage with snapshot data source [Feature:VolumeSnapshotDataSource]  \\\n",
+       "0                                                  0                                                                                                                                         \n",
+       "1                                                  0                                                                                                                                         \n",
+       "2                                                  0                                                                                                                                         \n",
+       "3                                                  0                                                                                                                                         \n",
+       "4                                                  0                                                                                                                                         \n",
+       "\n",
+       "   operator.Run template e2e-aws-scaleup-rhel7 - e2e-aws-scaleup-rhel7 container test  \\\n",
+       "0                                                  0                                    \n",
+       "1                                                  0                                    \n",
+       "2                                                  0                                    \n",
+       "3                                                  0                                    \n",
+       "4                                                  0                                    \n",
+       "\n",
+       "   [sig-storage] In-tree Volumes [Driver: aws] [Testpattern: Dynamic PV (ext4)] volumes should allow exec of files on the volume  \\\n",
+       "0                                                  0                                                                               \n",
+       "1                                                  0                                                                               \n",
+       "2                                                  0                                                                               \n",
+       "3                                                  0                                                                               \n",
+       "4                                                  0                                                                               \n",
+       "\n",
+       "   [sig-storage] In-tree Volumes [Driver: cinder] [Testpattern: Dynamic PV (block volmode)] volume-expand should not allow expansion of pvcs without AllowVolumeExpansion property  \\\n",
+       "0                                                  0                                                                                                                                 \n",
+       "1                                                  0                                                                                                                                 \n",
+       "2                                                  0                                                                                                                                 \n",
+       "3                                                  0                                                                                                                                 \n",
+       "4                                                  0                                                                                                                                 \n",
+       "\n",
+       "   operator.Run template e2e-aws-serial - e2e-aws-serial container test  \\\n",
+       "0                                                  0                      \n",
+       "1                                                  0                      \n",
+       "2                                                  0                      \n",
+       "3                                                  0                      \n",
+       "4                                                  0                      \n",
+       "\n",
+       "   [sig-storage] CSI Volumes [Driver: csi-hostpath] [Testpattern: Dynamic PV (filesystem volmode)] volumeLimits should support volume limits [Serial]  \\\n",
+       "0                                                  0                                                                                                    \n",
+       "1                                                  0                                                                                                    \n",
+       "2                                                  0                                                                                                    \n",
+       "3                                                  0                                                                                                    \n",
+       "4                                                  0                                                                                                    \n",
+       "\n",
+       "   [sig-storage] In-tree Volumes [Driver: azure-disk] [Testpattern: Inline-volume (default fs)] subPath should be able to unmount after the subpath directory is deleted  \n",
+       "0                                                  0                                                                                                                      \n",
+       "1                                                  0                                                                                                                      \n",
+       "2                                                  0                                                                                                                      \n",
+       "3                                                  0                                                                                                                      \n",
+       "4                                                  0                                                                                                                      \n",
+       "\n",
+       "[5 rows x 1455 columns]"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_encoded = pd.DataFrame(encoded.array, columns=vocab)\n",
+    "df_encoded.head()"
    ]
   },
   {
@@ -530,7 +866,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -557,16 +893,16 @@
    "source": [
     "### Remove noise/ unique tests\n",
     "\n",
-    "We want to make sure that our correlations are not just due to unique failed test sets present in our small dataset, and want to make sure our tests impact multiple jobs. For example, if we had a unique failed test set that only occured in a single example, and shared no other failed tests among the vocabualry, then all of the tests would appear to be 100% correlated with each other, when in fact that is mereley a consequence of insufficent data.     \n",
+    "We want to make sure that our correlations are not just due to unique failed test sets present in our small dataset, and want to make sure our tests impact multiple jobs. For example, if we had a unique failed test set that only occurred in a single example, and shared no other failed tests among the vocabulary, then all of the tests would appear to be 100% correlated with each other, when in fact that is merely a consequence of insufficient data.     \n",
     "\n",
     "In order to prevent that, lets ignore any tests that occur only in a single job.\n",
     "\n",
-    "In order to do that we will use `occurence_count` to create a filter vector for any test that occurs only once. Then filter them out of our working DF."
+    "In order to do that we will use `occurrence_count` to create a filter vector for any test that occurs only once. Then filter them out of our working DF."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -578,7 +914,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -591,7 +927,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -603,14 +939,23 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "occurence_count = df_encoded.sum()\n",
-    "occurence_count.sort_values(ascending=False).head(3)"
+    "occurrence_count = df_encoded.sum()\n",
+    "occurrence_count.sort_values(ascending=False).head(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filter_unique = list(occurrence_count[occurrence_count.values <= 1].index)"
    ]
   },
   {
@@ -619,21 +964,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "filter_unique = list(occurence_count[occurence_count.values <= 1].index)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "df_encoded = df_encoded.drop(filter_unique,axis=1)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -642,7 +978,7 @@
        "(102, 976)"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -656,21 +992,21 @@
    "metadata": {},
    "source": [
     "### After Filtering \n",
-    "We are left with 102 jobs with 976 possible test names. We can see here that we've dropped nearly 500 test names from our dataset, meaning that there were 500 that occurred in only 1 job, and corelation could not be well established.    "
+    "We are left with 102 jobs with 976 possible test names. We can see here that we've dropped nearly 500 test names from our dataset, meaning that there were 500 that occurred in only 1 job, and correlation could not be well established.    "
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Build Correlation Matix \n",
+    "### Build Correlation Matrix \n",
     "\n",
     "Here we will use pandas built in `df.corr()` function to get a correlation matrix between each of our tests failures."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -683,12 +1019,12 @@
    "source": [
     "Since there are 900 features, its not practical to visualize the entire correlation matrix, but to get a sense of the data lets look at a subset of our our data and see if any test pairs jump out as being highly correlated.\n",
     "\n",
-    "The best way to interpert the graph below is, white squares represent highly correlated failure pairs and black squares represent independent failure pairs. "
+    "The best way to interpret the graph below is, white squares represent highly correlated failure pairs and black squares represent independent failure pairs. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -715,12 +1051,12 @@
    "source": [
     "### Find highly correlated failure sets\n",
     "\n",
-    "Going thorough a 900 X 900 heatmap is probably not the most effecient way to find failure groups. Let's iterate through the correlation matrix and for each test, collect those tests that have a correlation coefficent of 0.9 or higher. "
+    "Going thorough a 900 X 900 heatmap is probably not the most efficient way to find failure groups. Let's iterate through the correlation matrix and for each test, collect those tests that have a correlation coefficient of 0.9 or higher. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -729,7 +1065,7 @@
        "976"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -753,7 +1089,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Examine Correalation Sets\n",
+    "### Examine Correlation Sets\n",
     "Then to make things easier, lets ignore all the tests for which there are no highly correlated tests. \n",
     "\n",
     "Finally lets look at the output of this and examine one of our sets of highly correlated test failures. "
@@ -761,45 +1097,104 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "186 sets\n"
+      "186 sets of correlated tests \n",
+      "\n",
+      "Feature of interest: [sig-builds][Feature:Builds] prune builds based on settings in the buildconfig  should prune errored builds based on the failedBuildsHistoryLimit setting\n"
      ]
     },
     {
      "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>test_name</th>\n",
+       "      <th>correlation coefficient</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>[sig-instrumentation][sig-builds][Feature:Builds] Prometheus when installed on the cluster should start and expose a secured proxy and verify buil...</td>\n",
+       "      <td>0.908153</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>[sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestrictions should be functional  Rolebinding restrictions tests single project should suc...</td>\n",
+       "      <td>0.908153</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>[sig-apps][Feature:OpenShiftControllerManager] TestTriggers_configChange</td>\n",
+       "      <td>0.908153</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>[sig-auth][Feature:OpenShiftAuthorization] authorization  TestClusterReaderCoverage should succeed</td>\n",
+       "      <td>0.908153</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>[sig-auth][Feature:OpenShiftAuthorization] self-SAR compatibility  TestSelfSubjectAccessReviewsNonExistingNamespace should succeed</td>\n",
+       "      <td>0.908153</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
       "text/plain": [
-       "('[sig-builds][Feature:Builds] prune builds based on settings in the buildconfig  should prune errored builds based on the failedBuildsHistoryLimit setting',\n",
-       " [('[sig-instrumentation][sig-builds][Feature:Builds] Prometheus when installed on the cluster should start and expose a secured proxy and verify build metrics',\n",
-       "   0.9081532183730032),\n",
-       "  ('[sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestrictions should be functional  Rolebinding restrictions tests single project should succeed',\n",
-       "   0.9081532183730032),\n",
-       "  ('[sig-apps][Feature:OpenShiftControllerManager] TestTriggers_configChange',\n",
-       "   0.9081532183730032),\n",
-       "  ('[sig-auth][Feature:OpenShiftAuthorization] authorization  TestClusterReaderCoverage should succeed',\n",
-       "   0.9081532183730032),\n",
-       "  ('[sig-auth][Feature:OpenShiftAuthorization] self-SAR compatibility  TestSelfSubjectAccessReviewsNonExistingNamespace should succeed',\n",
-       "   0.9081532183730032)])"
+       "                                                                                                                                               test_name  \\\n",
+       "0  [sig-instrumentation][sig-builds][Feature:Builds] Prometheus when installed on the cluster should start and expose a secured proxy and verify buil...   \n",
+       "1  [sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestrictions should be functional  Rolebinding restrictions tests single project should suc...   \n",
+       "2                                                                               [sig-apps][Feature:OpenShiftControllerManager] TestTriggers_configChange   \n",
+       "3                                                     [sig-auth][Feature:OpenShiftAuthorization] authorization  TestClusterReaderCoverage should succeed   \n",
+       "4                     [sig-auth][Feature:OpenShiftAuthorization] self-SAR compatibility  TestSelfSubjectAccessReviewsNonExistingNamespace should succeed   \n",
+       "\n",
+       "   correlation coefficient  \n",
+       "0                 0.908153  \n",
+       "1                 0.908153  \n",
+       "2                 0.908153  \n",
+       "3                 0.908153  \n",
+       "4                 0.908153  "
       ]
      },
-     "execution_count": 35,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "pd.set_option('display.max_colwidth', 150)\n",
     "# top_correlation has a number of empty rows as not all tests have high correlations with others, lets grab only the sets that do\n",
     "corr_sets = []\n",
     "for i in top_correlation.items():\n",
     "    if len(i[1]) >= 1:\n",
     "        corr_sets.append(i)\n",
-    "print(f'{len(corr_sets)} sets')\n",
-    "corr_sets[1]"
+    "print(f'{len(corr_sets)} sets of correlated tests \\n')\n",
+    "print(f'Feature of interest: {corr_sets[1][0]}')\n",
+    "pd.DataFrame(corr_sets[1][1],columns = [\"test_name\", \"correlation coefficient\"] )"
    ]
   },
   {
@@ -808,49 +1203,114 @@
    "source": [
     "### Validate correlation set\n",
     "\n",
-    "We can see from the output above that the test `[sig-builds][Feature:Builds] prune builds based on settings in the buildconfig  should prune errored builds based on the failedBuildsHistoryLimit setting` is highly correlated with these 5 other tests. They appear to cooccur almost all of the time (0.9). However, lets just double check and make sure this isen't a one-off occurence.  "
+    "We can see from the output above that the test `[sig-builds][Feature:Builds] prune builds based on settings in the buildconfig  should prune errored builds based on the failedBuildsHistoryLimit setting` is highly correlated with these 5 other tests. They appear to cooccur almost all of the time (0.9). However, lets just double check and make sure this isn't a one-off occurrence.  "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "6.0"
-      ]
-     },
-     "execution_count": 39,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "perc_present.loc['[sig-builds][Feature:Builds] prune builds based on settings in the buildconfig  should prune errored builds based on the failedBuildsHistoryLimit setting']//0.00980392156862745"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "5.0 ('[sig-instrumentation][sig-builds][Feature:Builds] Prometheus when installed on the cluster should start and expose a secured proxy and verify build metrics', 0.9081532183730032)\n",
-      "5.0 ('[sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestrictions should be functional  Rolebinding restrictions tests single project should succeed', 0.9081532183730032)\n",
-      "5.0 ('[sig-apps][Feature:OpenShiftControllerManager] TestTriggers_configChange', 0.9081532183730032)\n",
-      "5.0 ('[sig-auth][Feature:OpenShiftAuthorization] authorization  TestClusterReaderCoverage should succeed', 0.9081532183730032)\n",
-      "5.0 ('[sig-auth][Feature:OpenShiftAuthorization] self-SAR compatibility  TestSelfSubjectAccessReviewsNonExistingNamespace should succeed', 0.9081532183730032)\n"
+      "6 : the number of times this test failed in our data set\n"
      ]
     }
    ],
    "source": [
+    "num = occurrence_count.loc['[sig-builds][Feature:Builds] prune builds based on settings in the buildconfig  should prune errored builds based on the failedBuildsHistoryLimit setting']\n",
+    "print(f'{num} : the number of times this test failed in our data set')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>test_name</th>\n",
+       "      <th>num_occurrences</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>([sig-instrumentation][sig-builds][Feature:Builds] Prometheus when installed on the cluster should start and expose a secured proxy and verify bui...</td>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>([sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestrictions should be functional  Rolebinding restrictions tests single project should su...</td>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>([sig-apps][Feature:OpenShiftControllerManager] TestTriggers_configChange, 0.9081532183730032)</td>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>([sig-auth][Feature:OpenShiftAuthorization] authorization  TestClusterReaderCoverage should succeed, 0.9081532183730032)</td>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>([sig-auth][Feature:OpenShiftAuthorization] self-SAR compatibility  TestSelfSubjectAccessReviewsNonExistingNamespace should succeed, 0.90815321837...</td>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                                                                                                               test_name  \\\n",
+       "0  ([sig-instrumentation][sig-builds][Feature:Builds] Prometheus when installed on the cluster should start and expose a secured proxy and verify bui...   \n",
+       "1  ([sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestrictions should be functional  Rolebinding restrictions tests single project should su...   \n",
+       "2                                                         ([sig-apps][Feature:OpenShiftControllerManager] TestTriggers_configChange, 0.9081532183730032)   \n",
+       "3                               ([sig-auth][Feature:OpenShiftAuthorization] authorization  TestClusterReaderCoverage should succeed, 0.9081532183730032)   \n",
+       "4  ([sig-auth][Feature:OpenShiftAuthorization] self-SAR compatibility  TestSelfSubjectAccessReviewsNonExistingNamespace should succeed, 0.90815321837...   \n",
+       "\n",
+       "   num_occurrences  \n",
+       "0                5  \n",
+       "1                5  \n",
+       "2                5  \n",
+       "3                5  \n",
+       "4                5  "
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lst = []\n",
     "for i in top_correlation['[sig-builds][Feature:Builds] prune builds based on settings in the buildconfig  should prune errored builds based on the failedBuildsHistoryLimit setting']:\n",
-    "    print(perc_present[i[0]]//0.00980392156862745, i)"
+    "    lst.append((i, occurrence_count.loc[i[0]]))\n",
+    "    \n",
+    "pd.DataFrame(lst, columns=[\"test_name\",\"num_occurrences\"])"
    ]
   },
   {


### PR DESCRIPTION
Added fixes for better readability as suggested in #2 additional comments. 

* Converted results output to tables instead of standard print outputs
* Corrected a number of typos
* Changed method for finding count of test failures (used `occurrence_count` df instead of dividing by the percent value in `perc_present` df to remove odd reliance on dividing by `0.009`.
* Replaced a missing cell were the df `encoded_df` was created. 
 