### PR TITLE
Updates required for repo reproducibility as image on Jupyterhub

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,11 @@ Sphinx = "*"
 [packages]
 src = {editable = true, path = "./"}
 awscli = "*"
+pandas = "*"
+numpy = "*"
+scikit-learn = "*"
+matplotlib = "*"
+seaborn = "*"
 
 [requires]
-python_version = "3.8"
+python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "91a403a4cf038cbb97937e0d56125a8e408804f4d685097bd1062f8666f5759f"
+            "sha256": "758e8bb3973eee17d4a415f57fde4068ee6eae23dd89f2bfe457a8477be5ff57"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.8"
+            "python_version": "3.6"
         },
         "sources": [
             {
@@ -18,25 +18,24 @@
     "default": {
         "awscli": {
             "hashes": [
-                "sha256:05be15e54d4d0a650814d9cb570b0870baf2011a4bfb2a74073237f7a707f470",
-                "sha256:53accac94383af4559853f1bcd6f71f1e96d42f9b4147d9e4208810a18cd2914"
+                "sha256:6c01750a27c05cd37b86e95083805f518b847221231967f1f173daa9b00ec0df",
+                "sha256:ea73ebeca5a2783f58a930a54c1d2e0df28a365a90e6e4d2216eb198e016738b"
             ],
             "index": "pypi",
-            "version": "==1.18.80"
+            "version": "==1.18.180"
         },
         "botocore": {
             "hashes": [
-                "sha256:0ad4fb7b731e924490305584f7dcfd3e9fe955b307392b054a3d132a902a2528",
-                "sha256:13f4d92589ae9bd8c2c5ce8ea2f59d01a0ac4c14e9f99772ee4d1eb6cf9a3357"
+                "sha256:00a69a507e8b817d0703c612131e6cb3a3260579d0353c56d005bd9effd92ec0",
+                "sha256:4576ca751264c65420daae07e244beafdfea493b4fbb815d37215c0736dc4633"
             ],
-            "version": "==1.17.3"
+            "version": "==1.19.20"
         },
         "click": {
             "hashes": [
                 "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
                 "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==7.1.2"
         },
         "colorama": {
@@ -47,13 +46,19 @@
             "markers": "python_version != '3.4'",
             "version": "==0.4.3"
         },
+        "cycler": {
+            "hashes": [
+                "sha256:1d8a5ae1ff6c5cf9b93e8811e581232ad8920aeec647c37316ceac982b08cb2d",
+                "sha256:cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8"
+            ],
+            "version": "==0.10.0"
+        },
         "docutils": {
             "hashes": [
                 "sha256:6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0",
                 "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827",
                 "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==0.15.2"
         },
         "jmespath": {
@@ -61,41 +66,220 @@
                 "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9",
                 "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==0.10.0"
+        },
+        "joblib": {
+            "hashes": [
+                "sha256:698c311779f347cf6b7e6b8a39bb682277b8ee4aba8cf9507bc0cf4cd4737b72",
+                "sha256:9e284edd6be6b71883a63c9b7f124738a3c16195513ad940eae7e3438de885d5"
+            ],
+            "version": "==0.17.0"
+        },
+        "kiwisolver": {
+            "hashes": [
+                "sha256:0cd53f403202159b44528498de18f9285b04482bab2a6fc3f5dd8dbb9352e30d",
+                "sha256:1e1bc12fb773a7b2ffdeb8380609f4f8064777877b2225dec3da711b421fda31",
+                "sha256:225e2e18f271e0ed8157d7f4518ffbf99b9450fca398d561eb5c4a87d0986dd9",
+                "sha256:232c9e11fd7ac3a470d65cd67e4359eee155ec57e822e5220322d7b2ac84fbf0",
+                "sha256:31dfd2ac56edc0ff9ac295193eeaea1c0c923c0355bf948fbd99ed6018010b72",
+                "sha256:33449715e0101e4d34f64990352bce4095c8bf13bed1b390773fc0a7295967b3",
+                "sha256:401a2e9afa8588589775fe34fc22d918ae839aaaf0c0e96441c0fdbce6d8ebe6",
+                "sha256:44a62e24d9b01ba94ae7a4a6c3fb215dc4af1dde817e7498d901e229aaf50e4e",
+                "sha256:50af681a36b2a1dee1d3c169ade9fdc59207d3c31e522519181e12f1b3ba7000",
+                "sha256:563c649cfdef27d081c84e72a03b48ea9408c16657500c312575ae9d9f7bc1c3",
+                "sha256:5989db3b3b34b76c09253deeaf7fbc2707616f130e166996606c284395da3f18",
+                "sha256:5a7a7dbff17e66fac9142ae2ecafb719393aaee6a3768c9de2fd425c63b53e21",
+                "sha256:5c3e6455341008a054cccee8c5d24481bcfe1acdbc9add30aa95798e95c65621",
+                "sha256:5f6ccd3dd0b9739edcf407514016108e2280769c73a85b9e59aa390046dbf08b",
+                "sha256:72c99e39d005b793fb7d3d4e660aed6b6281b502e8c1eaf8ee8346023c8e03bc",
+                "sha256:78751b33595f7f9511952e7e60ce858c6d64db2e062afb325985ddbd34b5c131",
+                "sha256:834ee27348c4aefc20b479335fd422a2c69db55f7d9ab61721ac8cd83eb78882",
+                "sha256:8be8d84b7d4f2ba4ffff3665bcd0211318aa632395a1a41553250484a871d454",
+                "sha256:950a199911a8d94683a6b10321f9345d5a3a8433ec58b217ace979e18f16e248",
+                "sha256:a357fd4f15ee49b4a98b44ec23a34a95f1e00292a139d6015c11f55774ef10de",
+                "sha256:a53d27d0c2a0ebd07e395e56a1fbdf75ffedc4a05943daf472af163413ce9598",
+                "sha256:acef3d59d47dd85ecf909c359d0fd2c81ed33bdff70216d3956b463e12c38a54",
+                "sha256:b38694dcdac990a743aa654037ff1188c7a9801ac3ccc548d3341014bc5ca278",
+                "sha256:b9edd0110a77fc321ab090aaa1cfcaba1d8499850a12848b81be2222eab648f6",
+                "sha256:c08e95114951dc2090c4a630c2385bef681cacf12636fb0241accdc6b303fd81",
+                "sha256:c5518d51a0735b1e6cee1fdce66359f8d2b59c3ca85dc2b0813a8aa86818a030",
+                "sha256:c8fd0f1ae9d92b42854b2979024d7597685ce4ada367172ed7c09edf2cef9cb8",
+                "sha256:ca3820eb7f7faf7f0aa88de0e54681bddcb46e485beb844fcecbcd1c8bd01689",
+                "sha256:cf8b574c7b9aa060c62116d4181f3a1a4e821b2ec5cbfe3775809474113748d4",
+                "sha256:d3155d828dec1d43283bd24d3d3e0d9c7c350cdfcc0bd06c0ad1209c1bbc36d0",
+                "sha256:f8d6f8db88049a699817fd9178782867bf22283e3813064302ac59f61d95be05",
+                "sha256:fd34fbbfbc40628200730bc1febe30631347103fc8d3d4fa012c21ab9c11eca9"
+            ],
+            "version": "==1.3.1"
+        },
+        "matplotlib": {
+            "hashes": [
+                "sha256:09225edca87a79815822eb7d3be63a83ebd4d9d98d5aa3a15a94f4eee2435954",
+                "sha256:0caa687fce6174fef9b27d45f8cc57cbc572e04e98c81db8e628b12b563d59a2",
+                "sha256:27c9393fada62bd0ad7c730562a0fecbd3d5aaa8d9ed80ba7d3ebb8abc4f0453",
+                "sha256:2c2c5041608cb75c39cbd0ed05256f8a563e144234a524c59d091abbfa7a868f",
+                "sha256:2d31aff0c8184b05006ad756b9a4dc2a0805e94d28f3abc3187e881b6673b302",
+                "sha256:3a4c3e9be63adf8e9b305aa58fb3ec40ecc61fd0f8fd3328ce55bc30e7a2aeb0",
+                "sha256:5111d6d47a0f5b8f3e10af7a79d5e7eb7e73a22825391834734274c4f312a8a0",
+                "sha256:5ed3d3342698c2b1f3651f8ea6c099b0f196d16ee00e33dc3a6fee8cb01d530a",
+                "sha256:6ffd2d80d76df2e5f9f0c0140b5af97e3b87dd29852dcdb103ec177d853ec06b",
+                "sha256:746897fbd72bd462b888c74ed35d812ca76006b04f717cd44698cdfc99aca70d",
+                "sha256:756ee498b9ba35460e4cbbd73f09018e906daa8537fff61da5b5bf8d5e9de5c7",
+                "sha256:7ad44f2c74c50567c694ee91c6fa16d67e7c8af6f22c656b80469ad927688457",
+                "sha256:83e6c895d93fdf93eeff1a21ee96778ba65ef258e5d284160f7c628fee40c38f",
+                "sha256:9b03722c89a43a61d4d148acfc89ec5bb54cd0fd1539df25b10eb9c5fa6c393a",
+                "sha256:a4fe54eab2c7129add75154823e6543b10261f9b65b2abe692d68743a4999f8c",
+                "sha256:b1b60c6476c4cfe9e5cf8ab0d3127476fd3d5f05de0f343a452badaad0e4bdec",
+                "sha256:b26c472847911f5a7eb49e1c888c31c77c4ddf8023c1545e0e8e0367ba74fb15",
+                "sha256:b2a5e1f637a92bb6f3526cc54cc8af0401112e81ce5cba6368a1b7908f9e18bc",
+                "sha256:b7b09c61a91b742cb5460b72efd1fe26ef83c1c704f666e0af0df156b046aada",
+                "sha256:b8ba2a1dbb4660cb469fe8e1febb5119506059e675180c51396e1723ff9b79d9",
+                "sha256:c092fc4673260b1446b8578015321081d5db73b94533fe4bf9b69f44e948d174",
+                "sha256:c586ac1d64432f92857c3cf4478cfb0ece1ae18b740593f8a39f2f0b27c7fda5",
+                "sha256:d082f77b4ed876ae94a9373f0db96bf8768a7cca6c58fc3038f94e30ffde1880",
+                "sha256:e71cdd402047e657c1662073e9361106c6981e9621ab8c249388dfc3ec1de07b",
+                "sha256:eb6b6700ea454bb88333d98601e74928e06f9669c1ea231b4c4c666c1d7701b4"
+            ],
+            "index": "pypi",
+            "version": "==3.3.3"
+        },
+        "numpy": {
+            "hashes": [
+                "sha256:08308c38e44cc926bdfce99498b21eec1f848d24c302519e64203a8da99a97db",
+                "sha256:09c12096d843b90eafd01ea1b3307e78ddd47a55855ad402b157b6c4862197ce",
+                "sha256:13d166f77d6dc02c0a73c1101dd87fdf01339febec1030bd810dcd53fff3b0f1",
+                "sha256:141ec3a3300ab89c7f2b0775289954d193cc8edb621ea05f99db9cb181530512",
+                "sha256:16c1b388cc31a9baa06d91a19366fb99ddbe1c7b205293ed072211ee5bac1ed2",
+                "sha256:18bed2bcb39e3f758296584337966e68d2d5ba6aab7e038688ad53c8f889f757",
+                "sha256:1aeef46a13e51931c0b1cf8ae1168b4a55ecd282e6688fdb0a948cc5a1d5afb9",
+                "sha256:27d3f3b9e3406579a8af3a9f262f5339005dd25e0ecf3cf1559ff8a49ed5cbf2",
+                "sha256:2a2740aa9733d2e5b2dfb33639d98a64c3b0f24765fed86b0fd2aec07f6a0a08",
+                "sha256:4377e10b874e653fe96985c05feed2225c912e328c8a26541f7fc600fb9c637b",
+                "sha256:448ebb1b3bf64c0267d6b09a7cba26b5ae61b6d2dbabff7c91b660c7eccf2bdb",
+                "sha256:50e86c076611212ca62e5a59f518edafe0c0730f7d9195fec718da1a5c2bb1fc",
+                "sha256:5734bdc0342aba9dfc6f04920988140fb41234db42381cf7ccba64169f9fe7ac",
+                "sha256:64324f64f90a9e4ef732be0928be853eee378fd6a01be21a0a8469c4f2682c83",
+                "sha256:6ae6c680f3ebf1cf7ad1d7748868b39d9f900836df774c453c11c5440bc15b36",
+                "sha256:6d7593a705d662be5bfe24111af14763016765f43cb6923ed86223f965f52387",
+                "sha256:8cac8790a6b1ddf88640a9267ee67b1aee7a57dfa2d2dd33999d080bc8ee3a0f",
+                "sha256:8ece138c3a16db8c1ad38f52eb32be6086cc72f403150a79336eb2045723a1ad",
+                "sha256:9eeb7d1d04b117ac0d38719915ae169aa6b61fca227b0b7d198d43728f0c879c",
+                "sha256:a09f98011236a419ee3f49cedc9ef27d7a1651df07810ae430a6b06576e0b414",
+                "sha256:a5d897c14513590a85774180be713f692df6fa8ecf6483e561a6d47309566f37",
+                "sha256:ad6f2ff5b1989a4899bf89800a671d71b1612e5ff40866d1f4d8bcf48d4e5764",
+                "sha256:c42c4b73121caf0ed6cd795512c9c09c52a7287b04d105d112068c1736d7c753",
+                "sha256:cb1017eec5257e9ac6209ac172058c430e834d5d2bc21961dceeb79d111e5909",
+                "sha256:d6c7bb82883680e168b55b49c70af29b84b84abb161cbac2800e8fcb6f2109b6",
+                "sha256:e452dc66e08a4ce642a961f134814258a082832c78c90351b75c41ad16f79f63",
+                "sha256:e5b6ed0f0b42317050c88022349d994fe72bfe35f5908617512cd8c8ef9da2a9",
+                "sha256:e9b30d4bd69498fc0c3fe9db5f62fffbb06b8eb9321f92cc970f2969be5e3949",
+                "sha256:ec149b90019852266fec2341ce1db513b843e496d5a8e8cdb5ced1923a92faab",
+                "sha256:edb01671b3caae1ca00881686003d16c2209e07b7ef8b7639f1867852b948f7c",
+                "sha256:f0d3929fe88ee1c155129ecd82f981b8856c5d97bcb0d5f23e9b4242e79d1de3",
+                "sha256:f29454410db6ef8126c83bd3c968d143304633d45dc57b51252afbd79d700893",
+                "sha256:fe45becb4c2f72a0907c1d0246ea6449fe7a9e2293bb0e11c4e9a32bb0930a15",
+                "sha256:fedbd128668ead37f33917820b704784aff695e0019309ad446a6d0b065b57e4"
+            ],
+            "index": "pypi",
+            "version": "==1.19.4"
+        },
+        "pandas": {
+            "hashes": [
+                "sha256:09e0503758ad61afe81c9069505f8cb8c1e36ea8cc1e6826a95823ef5b327daf",
+                "sha256:0a11a6290ef3667575cbd4785a1b62d658c25a2fd70a5adedba32e156a8f1773",
+                "sha256:0d9a38a59242a2f6298fff45d09768b78b6eb0c52af5919ea9e45965d7ba56d9",
+                "sha256:112c5ba0f9ea0f60b2cc38c25f87ca1d5ca10f71efbee8e0f1bee9cf584ed5d5",
+                "sha256:185cf8c8f38b169dbf7001e1a88c511f653fbb9dfa3e048f5e19c38049e991dc",
+                "sha256:3aa8e10768c730cc1b610aca688f588831fa70b65a26cb549fbb9f35049a05e0",
+                "sha256:41746d520f2b50409dffdba29a15c42caa7babae15616bcf80800d8cfcae3d3e",
+                "sha256:43cea38cbcadb900829858884f49745eb1f42f92609d368cabcc674b03e90efc",
+                "sha256:5378f58172bd63d8c16dd5d008d7dcdd55bf803fcdbe7da2dcb65dbbf322f05b",
+                "sha256:54404abb1cd3f89d01f1fb5350607815326790efb4789be60508f458cdd5ccbf",
+                "sha256:5dac3aeaac5feb1016e94bde851eb2012d1733a222b8afa788202b836c97dad5",
+                "sha256:5fdb2a61e477ce58d3f1fdf2470ee142d9f0dde4969032edaf0b8f1a9dafeaa2",
+                "sha256:6613c7815ee0b20222178ad32ec144061cb07e6a746970c9160af1ebe3ad43b4",
+                "sha256:6d2b5b58e7df46b2c010ec78d7fb9ab20abf1d306d0614d3432e7478993fbdb0",
+                "sha256:8a5d7e57b9df2c0a9a202840b2881bb1f7a648eba12dd2d919ac07a33a36a97f",
+                "sha256:8b4c2055ebd6e497e5ecc06efa5b8aa76f59d15233356eb10dad22a03b757805",
+                "sha256:a15653480e5b92ee376f8458197a58cca89a6e95d12cccb4c2d933df5cecc63f",
+                "sha256:a7d2547b601ecc9a53fd41561de49a43d2231728ad65c7713d6b616cd02ddbed",
+                "sha256:a979d0404b135c63954dea79e6246c45dd45371a88631cdbb4877d844e6de3b6",
+                "sha256:b1f8111635700de7ac350b639e7e452b06fc541a328cf6193cf8fc638804bab8",
+                "sha256:c5a3597880a7a29a31ebd39b73b2c824316ae63a05c3c8a5ce2aea3fc68afe35",
+                "sha256:c681e8fcc47a767bf868341d8f0d76923733cbdcabd6ec3a3560695c69f14a1e",
+                "sha256:cf135a08f306ebbcfea6da8bf775217613917be23e5074c69215b91e180caab4",
+                "sha256:e2b8557fe6d0a18db4d61c028c6af61bfed44ef90e419ed6fadbdc079eba141e"
+            ],
+            "index": "pypi",
+            "version": "==1.1.4"
+        },
+        "pillow": {
+            "hashes": [
+                "sha256:006de60d7580d81f4a1a7e9f0173dc90a932e3905cc4d47ea909bc946302311a",
+                "sha256:0a2e8d03787ec7ad71dc18aec9367c946ef8ef50e1e78c71f743bc3a770f9fae",
+                "sha256:0eeeae397e5a79dc088d8297a4c2c6f901f8fb30db47795113a4a605d0f1e5ce",
+                "sha256:11c5c6e9b02c9dac08af04f093eb5a2f84857df70a7d4a6a6ad461aca803fb9e",
+                "sha256:2fb113757a369a6cdb189f8df3226e995acfed0a8919a72416626af1a0a71140",
+                "sha256:4b0ef2470c4979e345e4e0cc1bbac65fda11d0d7b789dbac035e4c6ce3f98adb",
+                "sha256:59e903ca800c8cfd1ebe482349ec7c35687b95e98cefae213e271c8c7fffa021",
+                "sha256:5abd653a23c35d980b332bc0431d39663b1709d64142e3652890df4c9b6970f6",
+                "sha256:5f9403af9c790cc18411ea398a6950ee2def2a830ad0cfe6dc9122e6d528b302",
+                "sha256:6b4a8fd632b4ebee28282a9fef4c341835a1aa8671e2770b6f89adc8e8c2703c",
+                "sha256:6c1aca8231625115104a06e4389fcd9ec88f0c9befbabd80dc206c35561be271",
+                "sha256:795e91a60f291e75de2e20e6bdd67770f793c8605b553cb6e4387ce0cb302e09",
+                "sha256:7ba0ba61252ab23052e642abdb17fd08fdcfdbbf3b74c969a30c58ac1ade7cd3",
+                "sha256:7c9401e68730d6c4245b8e361d3d13e1035cbc94db86b49dc7da8bec235d0015",
+                "sha256:81f812d8f5e8a09b246515fac141e9d10113229bc33ea073fec11403b016bcf3",
+                "sha256:895d54c0ddc78a478c80f9c438579ac15f3e27bf442c2a9aa74d41d0e4d12544",
+                "sha256:8de332053707c80963b589b22f8e0229f1be1f3ca862a932c1bcd48dafb18dd8",
+                "sha256:92c882b70a40c79de9f5294dc99390671e07fc0b0113d472cbea3fde15db1792",
+                "sha256:95edb1ed513e68bddc2aee3de66ceaf743590bf16c023fb9977adc4be15bd3f0",
+                "sha256:b63d4ff734263ae4ce6593798bcfee6dbfb00523c82753a3a03cbc05555a9cc3",
+                "sha256:bd7bf289e05470b1bc74889d1466d9ad4a56d201f24397557b6f65c24a6844b8",
+                "sha256:cc3ea6b23954da84dbee8025c616040d9aa5eaf34ea6895a0a762ee9d3e12e11",
+                "sha256:cc9ec588c6ef3a1325fa032ec14d97b7309db493782ea8c304666fb10c3bd9a7",
+                "sha256:d3d07c86d4efa1facdf32aa878bd508c0dc4f87c48125cc16b937baa4e5b5e11",
+                "sha256:d8a96747df78cda35980905bf26e72960cba6d355ace4780d4bdde3b217cdf1e",
+                "sha256:e38d58d9138ef972fceb7aeec4be02e3f01d383723965bfcef14d174c8ccd039",
+                "sha256:eb472586374dc66b31e36e14720747595c2b265ae962987261f044e5cce644b5",
+                "sha256:fbd922f702582cb0d71ef94442bfca57624352622d75e3be7a1e7e9360b07e72"
+            ],
+            "version": "==8.0.1"
         },
         "pyasn1": {
             "hashes": [
-                "sha256:014c0e9976956a08139dc0712ae195324a75e142284d5f87f1a87ee1b068a359",
-                "sha256:03840c999ba71680a131cfaee6fab142e1ed9bbd9c693e285cc6aca0d555e576",
-                "sha256:0458773cfe65b153891ac249bcf1b5f8f320b7c2ce462151f8fa74de8934becf",
-                "sha256:08c3c53b75eaa48d71cf8c710312316392ed40899cb34710d092e96745a358b7",
                 "sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d",
-                "sha256:5c9414dcfede6e441f7e8f81b43b34e834731003427e5b09e4e00e3172a10f00",
-                "sha256:6e7545f1a61025a4e58bb336952c5061697da694db1cae97b116e9c46abcf7c8",
-                "sha256:78fa6da68ed2727915c4767bb386ab32cdba863caa7dbe473eaae45f9959da86",
-                "sha256:7ab8a544af125fb704feadb008c99a88805126fb525280b2270bb25cc1d78a12",
-                "sha256:99fcc3c8d804d1bc6d9a099921e39d827026409a58f2a720dcdb89374ea0c776",
-                "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba",
-                "sha256:e89bf84b5437b532b0803ba5c9a5e054d21fec423a89952a74f87fa2c9b7bce2",
-                "sha256:fec3e9d8e36808a28efb59b489e4528c10ad0f480e57dcc32b4de5c9d8c9fdf3"
+                "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba"
             ],
             "version": "==0.4.8"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+            ],
+            "version": "==2.4.7"
         },
         "python-dateutil": {
             "hashes": [
                 "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
                 "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.8.1"
         },
         "python-dotenv": {
             "hashes": [
-                "sha256:25c0ff1a3e12f4bde8d592cc254ab075cfe734fc5dd989036716fd17ee7e5ec7",
-                "sha256:3b9909bc96b0edc6b01586e1eed05e71174ef4e04c71da5786370cebea53ad74"
+                "sha256:0c8d1b80d1a1e91717ea7d526178e3882732420b03f08afea0406db6402e220e",
+                "sha256:587825ed60b1711daea4832cf37524dfd404325b7db5e25ebe88c495c9f807a0"
             ],
-            "version": "==0.13.0"
+            "version": "==0.15.0"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:3e6b7dd2d1e0a59084bcee14a17af60c5c562cdc16d828e8eba2e683d3a7e268",
+                "sha256:5c55e189b682d420be27c6995ba6edce0c0a77dd67bfbe2ae6607134d5851ffd"
+            ],
+            "version": "==2020.4"
         },
         "pyyaml": {
             "hashes": [
@@ -116,10 +300,11 @@
         },
         "rsa": {
             "hashes": [
-                "sha256:25df4e10c263fb88b5ace923dd84bf9aa7f5019687b5e55382ffcdb8bede9db5",
-                "sha256:43f682fea81c452c98d09fc316aae12de6d30c4b5c84226642cf8f8fd1c93abd"
+                "sha256:35c5b5f6675ac02120036d97cf96f1fde4d49670543db2822ba5015e21a18032",
+                "sha256:4d409f5a7d78530a4a2062574c7bd80311bc3af29b364e293aa9b03eea77714f"
             ],
-            "version": "==3.4.2"
+            "markers": "python_version != '3.4'",
+            "version": "==4.5"
         },
         "s3transfer": {
             "hashes": [
@@ -128,25 +313,91 @@
             ],
             "version": "==0.3.3"
         },
+        "scikit-learn": {
+            "hashes": [
+                "sha256:0a127cc70990d4c15b1019680bfedc7fec6c23d14d3719fdf9b64b22d37cdeca",
+                "sha256:0d39748e7c9669ba648acf40fb3ce96b8a07b240db6888563a7cb76e05e0d9cc",
+                "sha256:1b8a391de95f6285a2f9adffb7db0892718950954b7149a70c783dc848f104ea",
+                "sha256:20766f515e6cd6f954554387dfae705d93c7b544ec0e6c6a5d8e006f6f7ef480",
+                "sha256:2aa95c2f17d2f80534156215c87bee72b6aa314a7f8b8fe92a2d71f47280570d",
+                "sha256:5ce7a8021c9defc2b75620571b350acc4a7d9763c25b7593621ef50f3bd019a2",
+                "sha256:6c28a1d00aae7c3c9568f61aafeaad813f0f01c729bee4fd9479e2132b215c1d",
+                "sha256:7671bbeddd7f4f9a6968f3b5442dac5f22bf1ba06709ef888cc9132ad354a9ab",
+                "sha256:914ac2b45a058d3f1338d7736200f7f3b094857758895f8667be8a81ff443b5b",
+                "sha256:98508723f44c61896a4e15894b2016762a55555fbf09365a0bb1870ecbd442de",
+                "sha256:a64817b050efd50f9abcfd311870073e500ae11b299683a519fbb52d85e08d25",
+                "sha256:cb3e76380312e1f86abd20340ab1d5b3cc46a26f6593d3c33c9ea3e4c7134028",
+                "sha256:d0dcaa54263307075cb93d0bee3ceb02821093b1b3d25f66021987d305d01dce",
+                "sha256:d9a1ce5f099f29c7c33181cc4386660e0ba891b21a60dc036bf369e3a3ee3aec",
+                "sha256:da8e7c302003dd765d92a5616678e591f347460ac7b53e53d667be7dfe6d1b10",
+                "sha256:daf276c465c38ef736a79bd79fc80a249f746bcbcae50c40945428f7ece074f8"
+            ],
+            "index": "pypi",
+            "version": "==0.23.2"
+        },
+        "scipy": {
+            "hashes": [
+                "sha256:168c45c0c32e23f613db7c9e4e780bc61982d71dcd406ead746c7c7c2f2004ce",
+                "sha256:213bc59191da2f479984ad4ec39406bf949a99aba70e9237b916ce7547b6ef42",
+                "sha256:25b241034215247481f53355e05f9e25462682b13bd9191359075682adcd9554",
+                "sha256:2c872de0c69ed20fb1a9b9cf6f77298b04a26f0b8720a5457be08be254366c6e",
+                "sha256:3397c129b479846d7eaa18f999369a24322d008fac0782e7828fa567358c36ce",
+                "sha256:368c0f69f93186309e1b4beb8e26d51dd6f5010b79264c0f1e9ca00cd92ea8c9",
+                "sha256:3d5db5d815370c28d938cf9b0809dade4acf7aba57eaf7ef733bfedc9b2474c4",
+                "sha256:4598cf03136067000855d6b44d7a1f4f46994164bcd450fb2c3d481afc25dd06",
+                "sha256:4a453d5e5689de62e5d38edf40af3f17560bfd63c9c5bd228c18c1f99afa155b",
+                "sha256:4f12d13ffbc16e988fa40809cbbd7a8b45bc05ff6ea0ba8e3e41f6f4db3a9e47",
+                "sha256:634568a3018bc16a83cda28d4f7aed0d803dd5618facb36e977e53b2df868443",
+                "sha256:65923bc3809524e46fb7eb4d6346552cbb6a1ffc41be748535aa502a2e3d3389",
+                "sha256:6b0ceb23560f46dd236a8ad4378fc40bad1783e997604ba845e131d6c680963e",
+                "sha256:8c8d6ca19c8497344b810b0b0344f8375af5f6bb9c98bd42e33f747417ab3f57",
+                "sha256:9ad4fcddcbf5dc67619379782e6aeef41218a79e17979aaed01ed099876c0e62",
+                "sha256:a254b98dbcc744c723a838c03b74a8a34c0558c9ac5c86d5561703362231107d",
+                "sha256:b03c4338d6d3d299e8ca494194c0ae4f611548da59e3c038813f1a43976cb437",
+                "sha256:cc1f78ebc982cd0602c9a7615d878396bec94908db67d4ecddca864d049112f2",
+                "sha256:d6d25c41a009e3c6b7e757338948d0076ee1dd1770d1c09ec131f11946883c54",
+                "sha256:d84cadd7d7998433334c99fa55bcba0d8b4aeff0edb123b2a1dfcface538e474",
+                "sha256:e360cb2299028d0b0d0f65a5c5e51fc16a335f1603aa2357c25766c8dab56938",
+                "sha256:e98d49a5717369d8241d6cf33ecb0ca72deee392414118198a8e5b4c35c56340",
+                "sha256:ed572470af2438b526ea574ff8f05e7f39b44ac37f712105e57fc4d53a6fb660",
+                "sha256:f87b39f4d69cf7d7529d7b1098cb712033b17ea7714aed831b95628f483fd012",
+                "sha256:fa789583fc94a7689b45834453fec095245c7e69c58561dc159b5d5277057e4c"
+            ],
+            "version": "==1.5.4"
+        },
+        "seaborn": {
+            "hashes": [
+                "sha256:390f8437b14f5ce845062f2865ad51656464c306d09bb97d7764c6cba1dd607c",
+                "sha256:62439a38482decdb263a8339f54ecb9823995ad8716abc830e91ca0753201e70"
+            ],
+            "index": "pypi",
+            "version": "==0.11.0"
+        },
         "six": {
             "hashes": [
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.15.0"
         },
         "src": {
             "editable": true,
-            "path": "."
+            "path": "./"
+        },
+        "threadpoolctl": {
+            "hashes": [
+                "sha256:38b74ca20ff3bb42caca8b00055111d74159ee95c4370882bbff2b93d24da725",
+                "sha256:ddc57c96a38beb63db45d6c159b5ab07b6bced12c45a1f07b2b92f272aebfa6b"
+            ],
+            "version": "==2.1.0"
         },
         "urllib3": {
             "hashes": [
-                "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527",
-                "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"
+                "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08",
+                "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"
             ],
             "markers": "python_version != '3.4'",
-            "version": "==1.25.9"
+            "version": "==1.26.2"
         }
     },
     "develop": {
@@ -159,18 +410,17 @@
         },
         "babel": {
             "hashes": [
-                "sha256:1aac2ae2d0d8ea368fa90906567f5c08463d98ade155c0c4bfedd6a0f7160e38",
-                "sha256:d670ea0b10f8b723672d3a6abeb87b565b244da220d76b4dba1b66269ec152d4"
+                "sha256:9d35c22fcc79893c3ecc85ac4a56cde1ecf3f19c540bba0922308a6c06ca6fa5",
+                "sha256:da031ab54472314f210b0adcff1588ee5d1d1d0ba4dbd07b94dba82bde791e05"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.8.0"
+            "version": "==2.9.0"
         },
         "certifi": {
             "hashes": [
-                "sha256:5ad7e9a056d25ffa5082862e36f119f7f7cec6457fa07ee2f8c339814b80c9b1",
-                "sha256:9cd41137dc19af6a5e03b630eefe7d1f458d964d406342dd3edf625839b944cc"
+                "sha256:1f422849db327d534e3d0c5f02a263458c3955ec0aae4ff09b95f195c59f4edd",
+                "sha256:f05def092c44fbf25834a51509ef6e631dc19765ab8a57b4e7ab85531f0a9cf4"
             ],
-            "version": "==2020.4.5.2"
+            "version": "==2020.11.8"
         },
         "chardet": {
             "hashes": [
@@ -181,40 +431,43 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:00f1d23f4336efc3b311ed0d807feb45098fc86dee1ca13b3d6768cdab187c8a",
-                "sha256:01333e1bd22c59713ba8a79f088b3955946e293114479bbfc2e37d522be03355",
-                "sha256:0cb4be7e784dcdc050fc58ef05b71aa8e89b7e6636b99967fadbdba694cf2b65",
-                "sha256:0e61d9803d5851849c24f78227939c701ced6704f337cad0a91e0972c51c1ee7",
-                "sha256:1601e480b9b99697a570cea7ef749e88123c04b92d84cedaa01e117436b4a0a9",
-                "sha256:2742c7515b9eb368718cd091bad1a1b44135cc72468c731302b3d641895b83d1",
-                "sha256:2d27a3f742c98e5c6b461ee6ef7287400a1956c11421eb574d843d9ec1f772f0",
-                "sha256:402e1744733df483b93abbf209283898e9f0d67470707e3c7516d84f48524f55",
-                "sha256:5c542d1e62eece33c306d66fe0a5c4f7f7b3c08fecc46ead86d7916684b36d6c",
-                "sha256:5f2294dbf7875b991c381e3d5af2bcc3494d836affa52b809c91697449d0eda6",
-                "sha256:6402bd2fdedabbdb63a316308142597534ea8e1895f4e7d8bf7476c5e8751fef",
-                "sha256:66460ab1599d3cf894bb6baee8c684788819b71a5dc1e8fa2ecc152e5d752019",
-                "sha256:782caea581a6e9ff75eccda79287daefd1d2631cc09d642b6ee2d6da21fc0a4e",
-                "sha256:79a3cfd6346ce6c13145731d39db47b7a7b859c0272f02cdb89a3bdcbae233a0",
-                "sha256:7a5bdad4edec57b5fb8dae7d3ee58622d626fd3a0be0dfceda162a7035885ecf",
-                "sha256:8fa0cbc7ecad630e5b0f4f35b0f6ad419246b02bc750de7ac66db92667996d24",
-                "sha256:a027ef0492ede1e03a8054e3c37b8def89a1e3c471482e9f046906ba4f2aafd2",
-                "sha256:a3f3654d5734a3ece152636aad89f58afc9213c6520062db3978239db122f03c",
-                "sha256:a82b92b04a23d3c8a581fc049228bafde988abacba397d57ce95fe95e0338ab4",
-                "sha256:acf3763ed01af8410fc36afea23707d4ea58ba7e86a8ee915dfb9ceff9ef69d0",
-                "sha256:adeb4c5b608574a3d647011af36f7586811a2c1197c861aedb548dd2453b41cd",
-                "sha256:b83835506dfc185a319031cf853fa4bb1b3974b1f913f5bb1a0f3d98bdcded04",
-                "sha256:bb28a7245de68bf29f6fb199545d072d1036a1917dca17a1e75bbb919e14ee8e",
-                "sha256:bf9cb9a9fd8891e7efd2d44deb24b86d647394b9705b744ff6f8261e6f29a730",
-                "sha256:c317eaf5ff46a34305b202e73404f55f7389ef834b8dbf4da09b9b9b37f76dd2",
-                "sha256:dbe8c6ae7534b5b024296464f387d57c13caa942f6d8e6e0346f27e509f0f768",
-                "sha256:de807ae933cfb7f0c7d9d981a053772452217df2bf38e7e6267c9cbf9545a796",
-                "sha256:dead2ddede4c7ba6cb3a721870f5141c97dc7d85a079edb4bd8d88c3ad5b20c7",
-                "sha256:dec5202bfe6f672d4511086e125db035a52b00f1648d6407cc8e526912c0353a",
-                "sha256:e1ea316102ea1e1770724db01998d1603ed921c54a86a2efcb03428d5417e489",
-                "sha256:f90bfc4ad18450c80b024036eaf91e4a246ae287701aaa88eaebebf150868052"
+                "sha256:0203acd33d2298e19b57451ebb0bed0ab0c602e5cf5a818591b4918b1f97d516",
+                "sha256:0f313707cdecd5cd3e217fc68c78a960b616604b559e9ea60cc16795c4304259",
+                "sha256:1c6703094c81fa55b816f5ae542c6ffc625fec769f22b053adb42ad712d086c9",
+                "sha256:1d44bb3a652fed01f1f2c10d5477956116e9b391320c94d36c6bf13b088a1097",
+                "sha256:280baa8ec489c4f542f8940f9c4c2181f0306a8ee1a54eceba071a449fb870a0",
+                "sha256:29a6272fec10623fcbe158fdf9abc7a5fa032048ac1d8631f14b50fbfc10d17f",
+                "sha256:2b31f46bf7b31e6aa690d4c7a3d51bb262438c6dcb0d528adde446531d0d3bb7",
+                "sha256:2d43af2be93ffbad25dd959899b5b809618a496926146ce98ee0b23683f8c51c",
+                "sha256:381ead10b9b9af5f64646cd27107fb27b614ee7040bb1226f9c07ba96625cbb5",
+                "sha256:47a11bdbd8ada9b7ee628596f9d97fbd3851bd9999d398e9436bd67376dbece7",
+                "sha256:4d6a42744139a7fa5b46a264874a781e8694bb32f1d76d8137b68138686f1729",
+                "sha256:50691e744714856f03a86df3e2bff847c2acede4c191f9a1da38f088df342978",
+                "sha256:530cc8aaf11cc2ac7430f3614b04645662ef20c348dce4167c22d99bec3480e9",
+                "sha256:582ddfbe712025448206a5bc45855d16c2e491c2dd102ee9a2841418ac1c629f",
+                "sha256:63808c30b41f3bbf65e29f7280bf793c79f54fb807057de7e5238ffc7cc4d7b9",
+                "sha256:71b69bd716698fa62cd97137d6f2fdf49f534decb23a2c6fc80813e8b7be6822",
+                "sha256:7858847f2d84bf6e64c7f66498e851c54de8ea06a6f96a32a1d192d846734418",
+                "sha256:78e93cc3571fd928a39c0b26767c986188a4118edc67bc0695bc7a284da22e82",
+                "sha256:7f43286f13d91a34fadf61ae252a51a130223c52bfefb50310d5b2deb062cf0f",
+                "sha256:86e9f8cd4b0cdd57b4ae71a9c186717daa4c5a99f3238a8723f416256e0b064d",
+                "sha256:8f264ba2701b8c9f815b272ad568d555ef98dfe1576802ab3149c3629a9f2221",
+                "sha256:9342dd70a1e151684727c9c91ea003b2fb33523bf19385d4554f7897ca0141d4",
+                "sha256:9361de40701666b034c59ad9e317bae95c973b9ff92513dd0eced11c6adf2e21",
+                "sha256:9669179786254a2e7e57f0ecf224e978471491d660aaca833f845b72a2df3709",
+                "sha256:aac1ba0a253e17889550ddb1b60a2063f7474155465577caa2a3b131224cfd54",
+                "sha256:aef72eae10b5e3116bac6957de1df4d75909fc76d1499a53fb6387434b6bcd8d",
+                "sha256:bd3166bb3b111e76a4f8e2980fa1addf2920a4ca9b2b8ca36a3bc3dedc618270",
+                "sha256:c1b78fb9700fc961f53386ad2fd86d87091e06ede5d118b8a50dea285a071c24",
+                "sha256:c3888a051226e676e383de03bf49eb633cd39fc829516e5334e69b8d81aae751",
+                "sha256:c5f17ad25d2c1286436761b462e22b5020d83316f8e8fcb5deb2b3151f8f1d3a",
+                "sha256:c851b35fc078389bc16b915a0a7c1d5923e12e2c5aeec58c52f4aa8085ac8237",
+                "sha256:cb7df71de0af56000115eafd000b867d1261f786b5eebd88a0ca6360cccfaca7",
+                "sha256:cedb2f9e1f990918ea061f28a0f0077a07702e3819602d3507e2ff98c8d20636",
+                "sha256:e8caf961e1b1a945db76f1b5fa9c91498d15f545ac0ababbe575cfab185d3bd8"
             ],
             "index": "pypi",
-            "version": "==5.1"
+            "version": "==5.3"
         },
         "docutils": {
             "hashes": [
@@ -222,39 +475,43 @@
                 "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827",
                 "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==0.15.2"
         },
         "flake8": {
             "hashes": [
-                "sha256:15e351d19611c887e482fb960eae4d44845013cc142d42896e9862f775d8cf5c",
-                "sha256:f04b9fcbac03b0a3e58c0ab3a0ecc462e023a9faf046d57794184028123aa208"
+                "sha256:749dbbd6bfd0cf1318af27bf97a14e28e5ff548ef8e5b1566ccfb25a11e7c839",
+                "sha256:aadae8761ec651813c24be05c6f7b4680857ef6afaae4651a4eccaef97ce6c3b"
             ],
             "index": "pypi",
-            "version": "==3.8.3"
+            "version": "==3.8.4"
         },
         "idna": {
             "hashes": [
-                "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
-                "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
+                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
+                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.9"
+            "version": "==2.10"
         },
         "imagesize": {
             "hashes": [
                 "sha256:6965f19a6a2039c7d48bca7dba2473069ff854c36ae6f19d2cde309d998228a1",
                 "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.2.0"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:77a540690e24b0305878c37ffd421785a6f7e53c8b5720d211b211de8d0e95da",
+                "sha256:cefa1a2f919b866c5beb7c9f7b0ebb4061f30a8a9bf16d609b000e2dfaceb9c3"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==2.0.0"
         },
         "jinja2": {
             "hashes": [
                 "sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0",
                 "sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==2.11.2"
         },
         "markupsafe": {
@@ -293,7 +550,6 @@
                 "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7",
                 "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.1.1"
         },
         "mccabe": {
@@ -308,7 +564,6 @@
                 "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8",
                 "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==20.4"
         },
         "pycodestyle": {
@@ -316,7 +571,6 @@
                 "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367",
                 "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.6.0"
         },
         "pyflakes": {
@@ -324,46 +578,41 @@
                 "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92",
                 "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.2.0"
         },
         "pygments": {
             "hashes": [
-                "sha256:647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44",
-                "sha256:ff7a40b4860b727ab48fad6360eb351cc1b33cbf9b15a0f689ca5353e9463324"
+                "sha256:381985fcc551eb9d37c52088a32914e00517e57f4a21609f48141ba08e193fa0",
+                "sha256:88a0bbcd659fcb9573703957c6b9cff9fab7295e6e76db54c9d00ae42df32773"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==2.6.1"
+            "version": "==2.7.2"
         },
         "pyparsing": {
             "hashes": [
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.4.7"
         },
         "pytz": {
             "hashes": [
-                "sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed",
-                "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"
+                "sha256:3e6b7dd2d1e0a59084bcee14a17af60c5c562cdc16d828e8eba2e683d3a7e268",
+                "sha256:5c55e189b682d420be27c6995ba6edce0c0a77dd67bfbe2ae6607134d5851ffd"
             ],
-            "version": "==2020.1"
+            "version": "==2020.4"
         },
         "requests": {
             "hashes": [
-                "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
-                "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"
+                "sha256:7f1a0b932f4a60a1a65caa4263921bb7d9ee911957e0ae4a23a6dd08185ad5f8",
+                "sha256:e786fa28d8c9154e6a4de5d46a1d921b8749f8b74e28bde23768e5e16eece998"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==2.23.0"
+            "version": "==2.25.0"
         },
         "six": {
             "hashes": [
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.15.0"
         },
         "snowballstemmer": {
@@ -375,18 +624,17 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:74fbead182a611ce1444f50218a1c5fc70b6cc547f64948f5182fb30a2a20258",
-                "sha256:97c9e3bcce2f61d9f5edf131299ee9d1219630598d9f9a8791459a4d9e815be5"
+                "sha256:1e8d592225447104d1172be415bc2972bd1357e3e12fdc76edf2261105db4300",
+                "sha256:d4e59ad4ea55efbb3c05cde3bfc83bfc14f0c95aa95c3d75346fcce186a47960"
             ],
             "index": "pypi",
-            "version": "==3.1.1"
+            "version": "==3.3.1"
         },
         "sphinxcontrib-applehelp": {
             "hashes": [
                 "sha256:806111e5e962be97c29ec4c1e7fe277bfd19e9652fb1a4392105b43e01af885a",
                 "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"
             ],
-            "markers": "python_version >= '3.5'",
             "version": "==1.0.2"
         },
         "sphinxcontrib-devhelp": {
@@ -394,7 +642,6 @@
                 "sha256:8165223f9a335cc1af7ffe1ed31d2871f325254c0423bc0c4c7cd1c1e4734a2e",
                 "sha256:ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4"
             ],
-            "markers": "python_version >= '3.5'",
             "version": "==1.0.2"
         },
         "sphinxcontrib-htmlhelp": {
@@ -402,7 +649,6 @@
                 "sha256:3c0bc24a2c41e340ac37c85ced6dafc879ab485c095b1d65d2461ac2f7cca86f",
                 "sha256:e8f5bb7e31b2dbb25b9cc435c8ab7a79787ebf7f906155729338f3156d93659b"
             ],
-            "markers": "python_version >= '3.5'",
             "version": "==1.0.3"
         },
         "sphinxcontrib-jsmath": {
@@ -410,7 +656,6 @@
                 "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178",
                 "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"
             ],
-            "markers": "python_version >= '3.5'",
             "version": "==1.0.1"
         },
         "sphinxcontrib-qthelp": {
@@ -418,7 +663,6 @@
                 "sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72",
                 "sha256:bd9fc24bcb748a8d51fd4ecaade681350aa63009a347a8c14e637895444dfab6"
             ],
-            "markers": "python_version >= '3.5'",
             "version": "==1.0.3"
         },
         "sphinxcontrib-serializinghtml": {
@@ -426,16 +670,22 @@
                 "sha256:eaa0eccc86e982a9b939b2b82d12cc5d013385ba5eadcc7e4fed23f4405f77bc",
                 "sha256:f242a81d423f59617a8e5cf16f5d4d74e28ee9a66f9e5b637a18082991db5a9a"
             ],
-            "markers": "python_version >= '3.5'",
             "version": "==1.1.4"
         },
         "urllib3": {
             "hashes": [
-                "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527",
-                "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"
+                "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08",
+                "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"
             ],
             "markers": "python_version != '3.4'",
-            "version": "==1.25.9"
+            "version": "==1.26.2"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108",
+                "sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb"
+            ],
+            "version": "==3.4.0"
         }
     }
 }

--- a/notebooks/TestGrid_indepth_EDA.ipynb
+++ b/notebooks/TestGrid_indepth_EDA.ipynb
@@ -38,32 +38,18 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Importing Jupyter notebook from TestGrid_EDA.ipynb\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
+    "import gzip\n",
     "import json\n",
     "import re\n",
     "import pandas as pd\n",
     "import numpy as np\n",
     "from itertools import groupby\n",
     "from scipy.stats import kurtosis\n",
-    "\n",
-    "# from scipy.spatial import distance\n",
     "from scipy.signal import convolve2d\n",
-    "\n",
-    "# import nbimporter\n",
-    "from TestGrid_EDA import decode_run_length\n",
     "import datetime\n",
     "from sklearn.linear_model import Ridge\n",
-    "\n",
-    "# from sklearn.preprocessing import MinMaxScaler\n",
     "from sklearn.cluster import DBSCAN\n",
     "from sklearn.decomposition import IncrementalPCA\n",
     "\n",
@@ -81,7 +67,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with open(\"../data/raw/testgrid_810.json\", \"r\") as read_file:\n",
+    "# Include necessary function from TestGrid_EDA.ipynb\n",
+    "def decode_run_length(x):\n",
+    "    lst = []\n",
+    "    for run_length in x:\n",
+    "        extension = [run_length[\"value\"]] * run_length[\"count\"]\n",
+    "        lst.extend(extension)\n",
+    "    return lst"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with gzip.open(\"../data/raw/testgrid_810.json.gz\", \"rb\") as read_file:\n",
     "    data = json.load(read_file)"
    ]
   },
@@ -98,7 +99,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -108,7 +109,7 @@
        "<IPython.core.display.Image object>"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -128,7 +129,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -168,7 +169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -213,173 +214,167 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "release-openshift-origin-installer-eXe-aws-compact-X.X\n",
-      "5 grids in this group, 6             shared tests out of 2494 unique tests in this grid type\n",
-      "release-openshift-ocp-installer-eXe-gcp-serial-X.X\n",
-      "6 grids in this group, 3             shared tests out of 223 unique tests in this grid type\n",
-      "release-openshift-origin-installer-eXe-aws-upgrade-rollback-X.X-to-X.X\n",
-      "6 grids in this group, 12             shared tests out of 87 unique tests in this grid type\n",
-      "release-openshift-ocp-installer-eXe-aws-ovn-X.X\n",
-      "5 grids in this group, 3             shared tests out of 3462 unique tests in this grid type\n",
-      "release-openshift-ocp-installer-cluster-logging-operator-eXe-X.X\n",
-      "3 grids in this group, 3             shared tests out of 551 unique tests in this grid type\n",
-      "release-openshift-ocp-installer-eXe-azure-ovn-X.X\n",
-      "5 grids in this group, 3             shared tests out of 2875 unique tests in this grid type\n",
-      "promote-release-openshift-machine-os-content-eXe-aws-X.X\n",
-      "7 grids in this group, 1             shared tests out of 2875 unique tests in this grid type\n",
-      "periodic-ci-openshift-release-master-ocp-X.X-eXe-vsphere\n",
-      "2 grids in this group, 953             shared tests out of 1114 unique tests in this grid type\n",
-      "release-openshift-ocp-installer-eXe-gcp-fips-serial-X.X\n",
-      "6 grids in this group, 0             shared tests out of 0 unique tests in this grid type\n",
-      "canary-release-openshift-origin-installer-eXe-aws-X.X-cnv\n",
-      "3 grids in this group, 36             shared tests out of 40 unique tests in this grid type\n",
-      "release-openshift-ocp-installer-eXe-aws-proxy-X.X\n",
-      "2 grids in this group, 623             shared tests out of 1260 unique tests in this grid type\n",
-      "release-openshift-ocp-installer-eXe-aws-fips-X.X\n",
-      "6 grids in this group, 0             shared tests out of 2558 unique tests in this grid type\n",
-      "periodic-ci-openshift-release-master-ocp-X.X-eXe-metal-ipi-compact\n",
-      "3 grids in this group, 9             shared tests out of 76 unique tests in this grid type\n",
-      "release-openshift-origin-installer-eXe-azure-upgrade-X.X\n",
-      "6 grids in this group, 19             shared tests out of 88 unique tests in this grid type\n",
-      "release-openshift-origin-installer-eXe-aws-sdn-multitenant-X.X\n",
-      "6 grids in this group, 3             shared tests out of 2792 unique tests in this grid type\n",
-      "release-openshift-ocp-installer-eXe-metal-X.X\n",
-      "6 grids in this group, 3             shared tests out of 2651 unique tests in this grid type\n",
-      "periodic-ci-openshift-release-master-ocp-X.X-eXe-vsphere-upi-serial\n",
-      "3 grids in this group, 49             shared tests out of 180 unique tests in this grid type\n",
-      "release-openshift-ocp-installer-eXe-openstack-X.X\n",
-      "6 grids in this group, 3             shared tests out of 3052 unique tests in this grid type\n",
-      "release-openshift-origin-installer-eXe-aws-ovn-network-stress-X.X\n",
-      "2 grids in this group, 39             shared tests out of 192 unique tests in this grid type\n",
-      "release-openshift-ocp-eXe-aws-scaleup-rhelX-X.X\n",
-      "4 grids in this group, 42             shared tests out of 2693 unique tests in this grid type\n",
-      "release-openshift-origin-installer-eXe-remote-libvirt-ppcXXle-X.X\n",
-      "4 grids in this group, 6             shared tests out of 2131 unique tests in this grid type\n",
-      "release-openshift-origin-installer-eXe-aws-X.X-cnv\n",
-      "2 grids in this group, 33             shared tests out of 38 unique tests in this grid type\n",
       "release-openshift-origin-installer-eXe-aws-shared-vpc-X.X\n",
       "5 grids in this group, 36             shared tests out of 2494 unique tests in this grid type\n",
-      "periodic-ci-openshift-release-master-ocp-X.X-eXe-vsphere-upi\n",
-      "3 grids in this group, 49             shared tests out of 2009 unique tests in this grid type\n",
-      "release-openshift-ocp-installer-eXe-gcp-fips-X.X\n",
-      "6 grids in this group, 0             shared tests out of 0 unique tests in this grid type\n",
-      "release-openshift-origin-installer-eXe-aws-sdn-network-stress-X.X\n",
-      "2 grids in this group, 39             shared tests out of 209 unique tests in this grid type\n",
-      "promote-release-openshift-okd-machine-os-content-eXe-aws-X.X\n",
-      "3 grids in this group, 0             shared tests out of 2002 unique tests in this grid type\n",
+      "release-openshift-ocp-installer-eXe-aws-fips-X.X\n",
+      "6 grids in this group, 0             shared tests out of 2558 unique tests in this grid type\n",
+      "promote-release-openshift-machine-os-content-eXe-aws-X.X\n",
+      "7 grids in this group, 1             shared tests out of 2875 unique tests in this grid type\n",
+      "release-openshift-ocp-installer-eXe-openstack-serial-X.X\n",
+      "6 grids in this group, 3             shared tests out of 211 unique tests in this grid type\n",
+      "release-openshift-ocp-installer-eXe-metal-X.X\n",
+      "6 grids in this group, 3             shared tests out of 2651 unique tests in this grid type\n",
+      "periodic-ci-openshift-release-master-ocp-X.X-eXe-vsphere-serial\n",
+      "2 grids in this group, 110             shared tests out of 142 unique tests in this grid type\n",
+      "release-openshift-ocp-installer-eXe-aws-proxy-X.X\n",
+      "2 grids in this group, 623             shared tests out of 1260 unique tests in this grid type\n",
+      "release-openshift-origin-installer-eXe-gcp-upgrade-X.X-stable-to-X.X-ci\n",
+      "3 grids in this group, 19             shared tests out of 126 unique tests in this grid type\n",
+      "release-openshift-origin-installer-eXe-aws-X.X\n",
+      "7 grids in this group, 34             shared tests out of 2899 unique tests in this grid type\n",
       "release-openshift-origin-installer-eXe-azure-shared-vpc-X.X\n",
       "5 grids in this group, 36             shared tests out of 2475 unique tests in this grid type\n",
       "release-openshift-ocp-installer-eXe-azure-fips-X.X\n",
       "6 grids in this group, 0             shared tests out of 0 unique tests in this grid type\n",
-      "release-openshift-ocp-installer-eXe-aws-mirrors-X.X\n",
-      "6 grids in this group, 3             shared tests out of 2796 unique tests in this grid type\n",
-      "release-openshift-ocp-installer-eXe-gcp-rt-X.X\n",
-      "4 grids in this group, 3             shared tests out of 1212 unique tests in this grid type\n",
-      "release-openshift-origin-installer-eXe-aws-calico-X.X\n",
-      "3 grids in this group, 12             shared tests out of 15 unique tests in this grid type\n",
-      "promote-release-openshift-machine-os-content-eXe-aws-X.X-sXXXx\n",
-      "6 grids in this group, 1             shared tests out of 1 unique tests in this grid type\n",
-      "release-openshift-ocp-installer-eXe-azure-serial-X.X\n",
-      "6 grids in this group, 3             shared tests out of 237 unique tests in this grid type\n",
-      "release-openshift-origin-installer-eXe-aws-upgrade-X.X-nightly-to-X.X-nightly\n",
-      "2 grids in this group, 23             shared tests out of 79 unique tests in this grid type\n",
-      "release-openshift-origin-installer-eXe-aws-upgrade-X.X-stable-to-X.X-nightly\n",
-      "2 grids in this group, 22             shared tests out of 26 unique tests in this grid type\n",
-      "release-openshift-origin-installer-eXe-gcp-compact-X.X\n",
-      "5 grids in this group, 36             shared tests out of 2534 unique tests in this grid type\n",
-      "release-openshift-ocp-installer-eXe-ovirt-upgrade-X.X-stable-to-X.X-ci\n",
-      "2 grids in this group, 46             shared tests out of 106 unique tests in this grid type\n",
-      "release-openshift-ocp-installer-eXe-aws-X.X\n",
-      "7 grids in this group, 3             shared tests out of 2946 unique tests in this grid type\n",
-      "release-openshift-origin-installer-eXe-aws-upgrade-fips-X.X\n",
-      "2 grids in this group, 49             shared tests out of 61 unique tests in this grid type\n",
-      "release-openshift-ocp-installer-eXe-azure-X.X\n",
-      "6 grids in this group, 3             shared tests out of 2784 unique tests in this grid type\n",
-      "release-openshift-origin-installer-eXe-gcp-serial-X.X\n",
-      "6 grids in this group, 36             shared tests out of 220 unique tests in this grid type\n",
-      "release-openshift-origin-installer-eXe-remote-libvirt-sXXXx-X.X\n",
-      "4 grids in this group, 6             shared tests out of 1963 unique tests in this grid type\n",
-      "release-openshift-origin-installer-eXe-gcp-shared-vpc-X.X\n",
-      "5 grids in this group, 36             shared tests out of 2609 unique tests in this grid type\n",
-      "release-openshift-ocp-installer-eXe-gcp-X.X\n",
-      "6 grids in this group, 3             shared tests out of 2874 unique tests in this grid type\n",
-      "release-openshift-ocp-installer-eXe-aws-fips-serial-X.X\n",
-      "6 grids in this group, 0             shared tests out of 0 unique tests in this grid type\n",
-      "release-openshift-origin-installer-eXe-aws-serial-X.X\n",
-      "7 grids in this group, 34             shared tests out of 227 unique tests in this grid type\n",
-      "release-openshift-origin-installer-eXe-gcp-X.X\n",
-      "6 grids in this group, 36             shared tests out of 2858 unique tests in this grid type\n",
-      "release-openshift-origin-installer-eXe-aws-X.X\n",
-      "7 grids in this group, 34             shared tests out of 2899 unique tests in this grid type\n",
-      "release-openshift-ocp-installer-eXe-vsphere-upi-X.X\n",
-      "2 grids in this group, 609             shared tests out of 1199 unique tests in this grid type\n",
       "release-openshift-origin-installer-eXe-aws-disruptive-X.X\n",
       "5 grids in this group, 11             shared tests out of 2011 unique tests in this grid type\n",
-      "promote-release-openshift-machine-os-content-eXe-aws-X.X-ppcXXle\n",
-      "5 grids in this group, 1             shared tests out of 1 unique tests in this grid type\n",
-      "release-openshift-origin-installer-eXe-aws-upgrade-X.X-to-X.X-to-X.X-to-X.X-ci\n",
-      "3 grids in this group, 1             shared tests out of 2549 unique tests in this grid type\n",
-      "release-openshift-okd-installer-eXe-aws-X.X\n",
-      "5 grids in this group, 3             shared tests out of 2088 unique tests in this grid type\n",
-      "release-openshift-ocp-installer-eXe-openstack-serial-X.X\n",
-      "6 grids in this group, 3             shared tests out of 211 unique tests in this grid type\n",
-      "release-openshift-ocp-installer-eXe-ovirt-X.X\n",
-      "4 grids in this group, 4             shared tests out of 1985 unique tests in this grid type\n",
-      "release-openshift-ocp-installer-elasticsearch-operator-eXe-X.X\n",
-      "3 grids in this group, 3             shared tests out of 40 unique tests in this grid type\n",
+      "release-openshift-origin-installer-eXe-remote-libvirt-ppcXXle-X.X\n",
+      "4 grids in this group, 6             shared tests out of 2131 unique tests in this grid type\n",
+      "release-openshift-origin-installer-eXe-aws-upgrade-fips-X.X\n",
+      "2 grids in this group, 49             shared tests out of 61 unique tests in this grid type\n",
+      "release-openshift-origin-installer-eXe-aws-upgrade-rollback-X.X-to-X.X\n",
+      "6 grids in this group, 12             shared tests out of 87 unique tests in this grid type\n",
+      "release-openshift-ocp-installer-eXe-gcp-fips-X.X\n",
+      "6 grids in this group, 0             shared tests out of 0 unique tests in this grid type\n",
+      "canary-release-openshift-origin-installer-eXe-aws-X.X-cnv\n",
+      "3 grids in this group, 36             shared tests out of 40 unique tests in this grid type\n",
       "release-openshift-ocp-installer-eXe-aws-serial-X.X\n",
       "7 grids in this group, 3             shared tests out of 231 unique tests in this grid type\n",
-      "release-openshift-ocp-installer-console-aws-X.X\n",
-      "6 grids in this group, 3             shared tests out of 1266 unique tests in this grid type\n",
-      "release-openshift-origin-installer-eXe-gcp-upgrade-X.X\n",
-      "6 grids in this group, 19             shared tests out of 134 unique tests in this grid type\n",
-      "release-openshift-ocp-installer-eXe-aws-csi-X.X\n",
-      "3 grids in this group, 3             shared tests out of 132 unique tests in this grid type\n",
-      "periodic-ci-openshift-release-master-ocp-X.X-eXe-aws-proxy\n",
-      "3 grids in this group, 54             shared tests out of 2116 unique tests in this grid type\n",
-      "periodic-ci-openshift-release-master-ocp-X.X-eXe-metal-ipi-ipvX\n",
-      "3 grids in this group, 11             shared tests out of 174 unique tests in this grid type\n",
-      "release-openshift-origin-installer-eXe-azure-compact-X.X\n",
-      "5 grids in this group, 36             shared tests out of 2465 unique tests in this grid type\n",
-      "periodic-ci-openshift-release-master-ocp-X.X-eXe-vsphere-serial\n",
-      "2 grids in this group, 110             shared tests out of 142 unique tests in this grid type\n",
-      "release-openshift-origin-installer-eXe-gcp-upgrade-X.X-stable-to-X.X-ci\n",
-      "3 grids in this group, 19             shared tests out of 126 unique tests in this grid type\n",
+      "release-openshift-origin-installer-eXe-aws-ovn-network-stress-X.X\n",
+      "2 grids in this group, 39             shared tests out of 192 unique tests in this grid type\n",
+      "release-openshift-ocp-installer-eXe-gcp-serial-X.X\n",
+      "6 grids in this group, 3             shared tests out of 223 unique tests in this grid type\n",
+      "release-openshift-ocp-eXe-aws-scaleup-rhelX-X.X\n",
+      "4 grids in this group, 42             shared tests out of 2693 unique tests in this grid type\n",
+      "promote-release-openshift-machine-os-content-eXe-aws-X.X-ppcXXle\n",
+      "5 grids in this group, 1             shared tests out of 1 unique tests in this grid type\n",
+      "release-openshift-ocp-installer-eXe-ovirt-upgrade-X.X-stable-to-X.X-ci\n",
+      "2 grids in this group, 46             shared tests out of 106 unique tests in this grid type\n",
+      "release-openshift-ocp-installer-eXe-ovirt-X.X\n",
+      "4 grids in this group, 4             shared tests out of 1985 unique tests in this grid type\n",
+      "release-openshift-origin-installer-eXe-gcp-X.X\n",
+      "6 grids in this group, 36             shared tests out of 2858 unique tests in this grid type\n",
+      "release-openshift-origin-installer-eXe-gcp-serial-X.X\n",
+      "6 grids in this group, 36             shared tests out of 220 unique tests in this grid type\n",
+      "release-openshift-origin-installer-eXe-gcp-compact-X.X\n",
+      "5 grids in this group, 36             shared tests out of 2534 unique tests in this grid type\n",
+      "release-openshift-origin-installer-eXe-aws-compact-X.X\n",
+      "5 grids in this group, 6             shared tests out of 2494 unique tests in this grid type\n",
       "release-openshift-ocp-installer-eXe-aws-upi-X.X\n",
       "6 grids in this group, 3             shared tests out of 2779 unique tests in this grid type\n",
-      "release-openshift-ocp-installer-eXe-vsphere-upi-serial-X.X\n",
-      "2 grids in this group, 75             shared tests out of 90 unique tests in this grid type\n",
-      "release-openshift-origin-installer-eXe-azure-upgrade-X.X-stable-to-X.X-ci\n",
-      "3 grids in this group, 19             shared tests out of 80 unique tests in this grid type\n",
-      "release-openshift-ocp-installer-eXe-gcp-ovn-X.X\n",
-      "5 grids in this group, 3             shared tests out of 2915 unique tests in this grid type\n",
+      "release-openshift-origin-installer-eXe-aws-serial-X.X\n",
+      "7 grids in this group, 34             shared tests out of 227 unique tests in this grid type\n",
+      "release-openshift-okd-installer-eXe-aws-X.X\n",
+      "5 grids in this group, 3             shared tests out of 2088 unique tests in this grid type\n",
+      "release-openshift-ocp-installer-eXe-gcp-rt-X.X\n",
+      "4 grids in this group, 3             shared tests out of 1212 unique tests in this grid type\n",
+      "release-openshift-origin-installer-eXe-azure-upgrade-X.X\n",
+      "6 grids in this group, 19             shared tests out of 88 unique tests in this grid type\n",
       "release-openshift-ocp-installer-eXe-metal-compact-X.X\n",
       "3 grids in this group, 909             shared tests out of 1055 unique tests in this grid type\n",
       "release-openshift-origin-installer-eXe-aws-upgrade-X.X-stable-to-X.X-ci\n",
       "5 grids in this group, 19             shared tests out of 129 unique tests in this grid type\n",
-      "release-openshift-origin-installer-old-rhcos-eXe-aws-X.X\n",
-      "6 grids in this group, 8             shared tests out of 2651 unique tests in this grid type\n",
-      "periodic-ci-openshift-release-master-ocp-X.X-eXe-metal-ipi\n",
-      "3 grids in this group, 11             shared tests out of 324 unique tests in this grid type\n",
+      "release-openshift-ocp-installer-eXe-vsphere-upi-X.X\n",
+      "2 grids in this group, 609             shared tests out of 1199 unique tests in this grid type\n",
+      "periodic-ci-openshift-release-master-ocp-X.X-eXe-vsphere-upi\n",
+      "3 grids in this group, 49             shared tests out of 2009 unique tests in this grid type\n",
       "release-openshift-origin-installer-eXe-aws-upgrade-rollback-X.X\n",
       "7 grids in this group, 18             shared tests out of 92 unique tests in this grid type\n",
+      "promote-release-openshift-okd-machine-os-content-eXe-aws-X.X\n",
+      "3 grids in this group, 0             shared tests out of 2002 unique tests in this grid type\n",
+      "release-openshift-ocp-installer-eXe-aws-X.X\n",
+      "7 grids in this group, 3             shared tests out of 2946 unique tests in this grid type\n",
+      "periodic-ci-openshift-release-master-ocp-X.X-eXe-vsphere-upi-serial\n",
+      "3 grids in this group, 49             shared tests out of 180 unique tests in this grid type\n",
       "release-openshift-ocp-installer-eXe-metal-serial-X.X\n",
-      "6 grids in this group, 3             shared tests out of 228 unique tests in this grid type\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "6 grids in this group, 3             shared tests out of 228 unique tests in this grid type\n",
+      "release-openshift-ocp-installer-eXe-azure-X.X\n",
+      "6 grids in this group, 3             shared tests out of 2784 unique tests in this grid type\n",
+      "release-openshift-origin-installer-eXe-aws-upgrade-X.X-to-X.X-to-X.X-to-X.X-ci\n",
+      "3 grids in this group, 1             shared tests out of 2549 unique tests in this grid type\n",
+      "periodic-ci-openshift-release-master-ocp-X.X-eXe-vsphere\n",
+      "2 grids in this group, 953             shared tests out of 1114 unique tests in this grid type\n",
+      "release-openshift-origin-installer-old-rhcos-eXe-aws-X.X\n",
+      "6 grids in this group, 8             shared tests out of 2651 unique tests in this grid type\n",
+      "release-openshift-origin-installer-eXe-aws-calico-X.X\n",
+      "3 grids in this group, 12             shared tests out of 15 unique tests in this grid type\n",
+      "release-openshift-ocp-installer-eXe-azure-ovn-X.X\n",
+      "5 grids in this group, 3             shared tests out of 2875 unique tests in this grid type\n",
+      "release-openshift-origin-installer-eXe-remote-libvirt-sXXXx-X.X\n",
+      "4 grids in this group, 6             shared tests out of 1963 unique tests in this grid type\n",
+      "release-openshift-ocp-installer-eXe-gcp-fips-serial-X.X\n",
+      "6 grids in this group, 0             shared tests out of 0 unique tests in this grid type\n",
+      "release-openshift-ocp-installer-elasticsearch-operator-eXe-X.X\n",
+      "3 grids in this group, 3             shared tests out of 40 unique tests in this grid type\n",
+      "release-openshift-ocp-installer-eXe-aws-mirrors-X.X\n",
+      "6 grids in this group, 3             shared tests out of 2796 unique tests in this grid type\n",
+      "periodic-ci-openshift-release-master-ocp-X.X-eXe-metal-ipi-compact\n",
+      "3 grids in this group, 9             shared tests out of 76 unique tests in this grid type\n",
+      "release-openshift-ocp-installer-eXe-vsphere-upi-serial-X.X\n",
+      "2 grids in this group, 75             shared tests out of 90 unique tests in this grid type\n",
+      "release-openshift-ocp-installer-cluster-logging-operator-eXe-X.X\n",
+      "3 grids in this group, 3             shared tests out of 551 unique tests in this grid type\n",
       "release-openshift-ocp-installer-eXe-azure-fips-serial-X.X\n",
-      "6 grids in this group, 0             shared tests out of 0 unique tests in this grid type\n"
+      "6 grids in this group, 0             shared tests out of 0 unique tests in this grid type\n",
+      "release-openshift-ocp-installer-eXe-aws-fips-serial-X.X\n",
+      "6 grids in this group, 0             shared tests out of 0 unique tests in this grid type\n",
+      "release-openshift-origin-installer-eXe-azure-compact-X.X\n",
+      "5 grids in this group, 36             shared tests out of 2465 unique tests in this grid type\n",
+      "release-openshift-ocp-installer-eXe-azure-serial-X.X\n",
+      "6 grids in this group, 3             shared tests out of 237 unique tests in this grid type\n",
+      "release-openshift-ocp-installer-console-aws-X.X\n",
+      "6 grids in this group, 3             shared tests out of 1266 unique tests in this grid type\n",
+      "release-openshift-origin-installer-eXe-gcp-upgrade-X.X\n",
+      "6 grids in this group, 19             shared tests out of 134 unique tests in this grid type\n",
+      "release-openshift-ocp-installer-eXe-aws-ovn-X.X\n",
+      "5 grids in this group, 3             shared tests out of 3462 unique tests in this grid type\n",
+      "release-openshift-origin-installer-eXe-aws-sdn-network-stress-X.X\n",
+      "2 grids in this group, 39             shared tests out of 209 unique tests in this grid type\n",
+      "promote-release-openshift-machine-os-content-eXe-aws-X.X-sXXXx\n",
+      "6 grids in this group, 1             shared tests out of 1 unique tests in this grid type\n",
+      "release-openshift-ocp-installer-eXe-aws-csi-X.X\n",
+      "3 grids in this group, 3             shared tests out of 132 unique tests in this grid type\n",
+      "release-openshift-ocp-installer-eXe-gcp-ovn-X.X\n",
+      "5 grids in this group, 3             shared tests out of 2915 unique tests in this grid type\n",
+      "release-openshift-origin-installer-eXe-aws-upgrade-X.X-stable-to-X.X-nightly\n",
+      "2 grids in this group, 22             shared tests out of 26 unique tests in this grid type\n",
+      "periodic-ci-openshift-release-master-ocp-X.X-eXe-metal-ipi-ipvX\n",
+      "3 grids in this group, 11             shared tests out of 174 unique tests in this grid type\n",
+      "release-openshift-ocp-installer-eXe-openstack-X.X\n",
+      "6 grids in this group, 3             shared tests out of 3052 unique tests in this grid type\n",
+      "release-openshift-origin-installer-eXe-azure-upgrade-X.X-stable-to-X.X-ci\n",
+      "3 grids in this group, 19             shared tests out of 80 unique tests in this grid type\n",
+      "release-openshift-origin-installer-eXe-aws-X.X-cnv\n",
+      "2 grids in this group, 33             shared tests out of 38 unique tests in this grid type\n",
+      "periodic-ci-openshift-release-master-ocp-X.X-eXe-aws-proxy\n",
+      "3 grids in this group, 54             shared tests out of 2116 unique tests in this grid type\n",
+      "release-openshift-ocp-installer-eXe-gcp-X.X\n",
+      "6 grids in this group, 3             shared tests out of 2874 unique tests in this grid type\n",
+      "release-openshift-origin-installer-eXe-gcp-shared-vpc-X.X\n",
+      "5 grids in this group, 36             shared tests out of 2609 unique tests in this grid type\n",
+      "periodic-ci-openshift-release-master-ocp-X.X-eXe-metal-ipi\n",
+      "3 grids in this group, 11             shared tests out of 324 unique tests in this grid type\n",
+      "release-openshift-origin-installer-eXe-aws-upgrade-X.X-nightly-to-X.X-nightly\n",
+      "2 grids in this group, 23             shared tests out of 79 unique tests in this grid type\n",
+      "release-openshift-origin-installer-eXe-aws-sdn-multitenant-X.X\n",
+      "6 grids in this group, 3             shared tests out of 2792 unique tests in this grid type\n"
      ]
     }
    ],
@@ -437,7 +432,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -453,7 +448,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -462,7 +457,7 @@
        "177291"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -473,27 +468,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Overall                                                                                                                                                                                                                    0.915633\n",
-       "operator.All images are built and tagged into stable                                                                                                                                                                       0.786600\n",
-       "operator.Import the release payload \"latest\" from an external source                                                                                                                                                       0.751861\n",
-       "operator install console                                                                                                                                                                                                   0.533499\n",
-       "operator install openshift-controller-manager                                                                                                                                                                              0.533499\n",
-       "                                                                                                                                                                                                                             ...   \n",
-       "DNS should answer endpoint and wildcard queries for the cluster [Conformance] [Suite:openshift/conformance/parallel/minimal]                                                                                               0.002481\n",
-       "[sig-storage] In-tree Volumes [Driver: nfs] [Testpattern: Dynamic PV (delayed binding)] topology should provision a volume and schedule a pod with AllowedTopologies [Suite:openshift/conformance/parallel] [Suite:k8s]    0.002481\n",
-       "operator.Tag the image haproxy-router into the image stream tag stable:haproxy-router                                                                                                                                      0.002481\n",
-       "[sig-storage] Projected updates should be reflected in volume [NodeConformance] [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]                                                                   0.002481\n",
-       "Create a test namespace.creates test namespace test-dqubp if necessary                                                                                                                                                     0.002481\n",
+       "Overall                                                                                                                                                                                                                                                                                                                   0.915633\n",
+       "operator.All images are built and tagged into stable                                                                                                                                                                                                                                                                      0.786600\n",
+       "operator.Import the release payload \"latest\" from an external source                                                                                                                                                                                                                                                      0.751861\n",
+       "operator install kube-controller-manager                                                                                                                                                                                                                                                                                  0.533499\n",
+       "operator install operator-lifecycle-manager                                                                                                                                                                                                                                                                               0.533499\n",
+       "                                                                                                                                                                                                                                                                                                                            ...   \n",
+       "[Area:Networking] services when using a plugin that isolates namespaces by default [Top Level] [Area:Networking] services when using a plugin that isolates namespaces by default should prevent connections to pods in different namespaces on different nodes via service IPs [Suite:openshift/conformance/parallel]    0.002481\n",
+       "Create a test namespace.creates test namespace test-ouywk if necessary                                                                                                                                                                                                                                                    0.002481\n",
+       "[sig-storage] Subpath Atomic writer volumes should support subpaths with projected pod [Suite:openshift/conformance/parallel] [Suite:k8s]                                                                                                                                                                                 0.002481\n",
+       "[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: dir] [Testpattern: Inline-volume (ext3)] volumes should be mountable [Suite:openshift/conformance/parallel] [Suite:k8s]                                                                                                                                    0.002481\n",
+       "External Storage [Driver: ebs.csi.aws.com] [Testpattern: Pre-provisioned PV (default fs)] volumes should allow exec of files on the volume                                                                                                                                                                                0.002481\n",
        "Length: 7798, dtype: float64"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -505,27 +500,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Overall                                                                                                                                                                                                                           369\n",
-       "operator.All images are built and tagged into stable                                                                                                                                                                              317\n",
-       "operator.Import the release payload \"latest\" from an external source                                                                                                                                                              303\n",
-       "operator install console                                                                                                                                                                                                          215\n",
-       "operator install openshift-controller-manager                                                                                                                                                                                     215\n",
-       "                                                                                                                                                                                                                                 ... \n",
-       "operator.Run template e2e-gcp-serial - e2e-gcp-serial container teardown                                                                                                                                                           11\n",
-       "[sig-scheduling] SchedulerPreemption [Serial] validates lower priority pod preemption by critical pod [Conformance] [Suite:openshift/conformance/serial/minimal] [Suite:k8s]                                                       11\n",
-       "[sig-arch] ocp payload should be based on existing source [Serial] olm version should contain the source commit id [Suite:openshift/conformance/serial]                                                                            11\n",
-       "[sig-storage] PersistentVolumes-local  [Volume type: blockfswithoutformat] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted [Suite:openshift/conformance/parallel] [Suite:k8s]     11\n",
-       "operator.Run template e2e-gcp-serial - e2e-gcp-serial container test                                                                                                                                                               11\n",
+       "Overall                                                                                                                                                                                            369\n",
+       "operator.All images are built and tagged into stable                                                                                                                                               317\n",
+       "operator.Import the release payload \"latest\" from an external source                                                                                                                               303\n",
+       "operator install kube-controller-manager                                                                                                                                                           215\n",
+       "operator install operator-lifecycle-manager                                                                                                                                                        215\n",
+       "                                                                                                                                                                                                  ... \n",
+       "[sig-scheduling] SchedulerPreemption [Serial] PreemptionExecutionPath runs ReplicaSets to verify preemption running path [Conformance] [Suite:openshift/conformance/serial/minimal] [Suite:k8s]     11\n",
+       "[sig-arch] ocp payload should be based on existing source [Serial] olm version should contain the source commit id [Suite:openshift/conformance/serial]                                             11\n",
+       "[sig-scheduling] SchedulerPreemption [Serial] validates basic preemption works [Suite:openshift/conformance/serial] [Suite:k8s]                                                                     11\n",
+       "operator.Run template e2e-gcp-serial - e2e-gcp-serial container teardown                                                                                                                            11\n",
+       "[sig-scheduling] SchedulerPreemption [Serial] validates lower priority pod preemption by critical pod [Suite:openshift/conformance/serial] [Suite:k8s]                                              11\n",
        "Length: 3137, dtype: int64"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -560,7 +555,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -569,7 +564,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -591,7 +586,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -626,7 +621,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -652,7 +647,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -672,7 +667,7 @@
        "Name: RL, Length: 317, dtype: int64"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -694,7 +689,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -706,7 +701,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -721,7 +716,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -767,7 +762,7 @@
        "0  [2020-10-08 16:48:05, 2020-10-08 15:12:01, 202...  "
       ]
      },
-     "execution_count": 18,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -778,7 +773,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -981,7 +976,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1019,7 +1014,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1047,7 +1042,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1066,7 +1061,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -1220,7 +1215,7 @@
        "[317 rows x 6 columns]"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1251,7 +1246,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1263,7 +1258,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -1284,7 +1279,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1294,7 +1289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -1337,7 +1332,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1356,7 +1351,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -1365,7 +1360,7 @@
        "(11927, 3)"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1376,7 +1371,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1395,7 +1390,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -1486,7 +1481,7 @@
        "4   0.000000 -0.056302  12.105453         0.388889  0.002778   0.022222"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1497,7 +1492,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -1522,7 +1517,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1532,7 +1527,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
@@ -1573,7 +1568,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1606,7 +1601,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
@@ -1620,7 +1615,7 @@
        " 'avg_frequency': 0.1669826612570952}"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1647,7 +1642,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1683,7 +1678,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1697,21 +1692,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'pass_rate': 0.0,\n",
-       " 'avg_coef': 0.006439196000536663,\n",
-       " 'avg_intercept': 0.16410103475871535,\n",
-       " 'avg_failure_streak': 0.03111111111111111,\n",
-       " 'avg_kurtosis': 0.40975324049463424,\n",
-       " 'avg_frequency': 0.08805555555555555}"
+       "{'pass_rate': 0.7539586117130891,\n",
+       " 'avg_coef': -0.0006371406635070356,\n",
+       " 'avg_intercept': 0.7672878478322255,\n",
+       " 'avg_failure_streak': 0.0,\n",
+       " 'avg_kurtosis': 0.05969594569818218,\n",
+       " 'avg_frequency': 0.17192680760898754}"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1722,7 +1717,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1738,7 +1733,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1750,12 +1745,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAo0AAAHUCAYAAABfxBLvAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/d3fzzAAAACXBIWXMAAAsTAAALEwEAmpwYAAA4SklEQVR4nO3df3RU9Z3/8df8SAIF0uAYCFS/2I1VYlaX2p7TzVINoD2IC1qz27PilmXlW7aru7rbriiunm112RZqV21Ru5WKAipnt6dgv0EoKwVTF9O1p8Jqk4Ca41prDNIRTgiGJJOZ7x/pHWcmc++dH3fm3pl5Ps5pJfPj5jOfJJNXPj/eH18sFosJAAAAsOB3uwEAAADwPkIjAAAAbBEaAQAAYIvQCAAAAFuERgAAANgiNAIAAMBW0O0GGE6cOK1otHKr/4RCUxUOD7rdjLJBfzqL/nQOfeks+tNZ9KdzSrUv/X6fpk+fkvY+z4TGaDRW0aFRUsW/fqfRn86iP51DXzqL/nQW/emccutLpqcBAABgi9AIAAAAW4RGAAAA2CI0AgAAwBahEQAAALYIjQAAALBFaAQAAIAtQiMAAABsERoBAABgi9AIAAAAW4RGAAAA2CI0AgAAwBahEQAAALYIjQAAALAVdLsBQLno7OrXjo5ehQeGFaqtUVtro1qaG9xuFgAAjiA0Ag7o7OrXlj1HNBKJSpLCA8PasueIJBEcAQBlwZHQeOLECd1+++369a9/rerqas2ZM0f33nuvzjrrLCcuD3jejo7eeGA0jESi2tHRS2gEAJQFR9Y0+nw+felLX9LevXvV3t6uc889V9/+9reduDRQEsIDw1ndDgBAqXEkNNbV1ekzn/lM/ON58+apr6/PiUsDJSFUW5PV7QAAlBrHd09Ho1Ft375dixYtcvrSgGe1tTaqOpj841Qd9KuttdGlFgEA4CxfLBaLOXnBe+65R8eOHdNDDz0kv5+KPqgcz//ybW3d06PfnhjS2dMn6y+WNGnBp851u1kAADjC0dC4YcMGHT16VP/2b/+m6urqrJ4bDg8qGnU0v5aU+vppOn78lNvNKBv0p7PoT+fQl86iP51FfzqnVPvS7/cpFJqa9j7HSu7cf//9+tWvfqVHH30068AIAAAAb3MkNL7++uv6/ve/r/POO0/XX3+9JOmcc87Rww8/7MTlAQAA4DJHQuMnPvEJHT161IlLAQAAwIPYqQIAAABbHCMI5GnV+v0Tbtu8lpJTAIDywkgjkId0gdHqdgAAShWhEQAAALYIjQAAALBFaAQAAIAtQiMAAABsERqBPJjtkmb3NACg3FByB8gTAREAUAkYaQQAAIAtQiMAAABsERoBAABgi9AIAAAAW4RGAAAA2CI0AgAAwBahEQAAALYIjQAAALBFaAQAAIAtQiMAAABsERoBAABgi9AIAAAAW4RGAAAA2CI0AgAAwBahEQAAALYIjQAAALBFaAQAAICtoNsNAErNl+/br9GxDz+uCkjfX7PIvQYBAFAEjDQCWUgNjJI0OjZ+OwAA5YzQCGQhNTDa3Q4AQLkgNAIAAMAWoREAAAC2CI1AFqoC2d0OAEC5IDQCWfj+mkUTAiK7pwEAlYCSO0CWCIgAgErESCMAAABsERoBAABgi9AIAAAAW4RGAAAA2CI0AgAAwBahEQAAALYIjQAAALBFnUYgA51d/drR0avwwLBCtTVqa21US3OD280CAKBoCI2Ajc6ufm3Zc0QjkagkKTwwrC17jkgSwREAUDGYngZs7OjojQdGw0gkqh0dvS61CACA4iM0AjbCA8NZ3Q4AQDkiNAI2QrU1Wd0OAEA5IjQCNtpaG1UdTP5RqQ761dba6FKLAAAoPjbCADaMzS7sngYAVDJCI5CBluYGQiIAoKIxPQ0AAABbhEYAAADYqqjpaU71AAAAyE3FhEZO9QAAAMhdxUxPc6oHAABA7iomNHKqBwAAQO4qJjRyqgcAAEDuKiY0cqoHAABA7ipmIwynegAAAOSuYkKjxKkeAAAAuaqY6WkAAADkjtAIAAAAW4RGAAAA2CI0AgAAwBahEQAAALYIjQAAALBFaAQAAIAtx0Ljhg0btGjRIl144YV67bXXnLosAAAAPMCx0HjFFVfoqaee0sc+9jGnLgkAAACPcOxEmE9/+tNOXQoAAAAew5pGAAAA2PLM2dOh0FS3m+C6+vppbjehrNCfzqI/nUNfOov+dBb96Zxy60vPhMZweFDRaMztZrimvn6ajh8/5XYzygb96Sz60zn0pbPoT2fRn84p1b70+32mA3lMTwMAAMCWY6Fx3bp1uvzyy9Xf368bb7xRf/zHf+zUpQEAAOAyx6an7777bt19991OXQ4AAAAewvQ0AAAAbBEaAQAAYIvQCAAAAFuERgAAANgiNAIAAMAWoREAAAC2CI0AAACwRWgEAACALUIjAAAAbBEaAQAAYMuxYwThbZ1d/drR0avwwLBCtTVqa21US3OD280CAAAlgtBYATq7+rVlzxGNRKKSpPDAsLbsOSJJBEcAAJARpqcrwI6O3nhgNIxEotrR0etSiwAAQKkhNFaA8MBwVrcDAACkYnq6AoRqa9IGxFBtjQut8a5te4+o43CfojHJ75Na583WisVz3W4WAACewEhjBWhrbVR1MPlLXR30q6210aUWec+2vUd04NB4YJSkaEw6cKhP2/YecbdhAAB4BKGxArQ0N2jlkrnxkcVQbY1WLpnLJpgEHYf7srodAIBKw/R0hWhpbiAkWjBGGDO9HQCASkNoRFF4vU6k35c+IPp9xW8LAABexPQ0Cs6oE2lsxjHqRHZ29bvcsg+1zpud1e0AAFQaRhqRpBAjgmZ1Irfve80zo4/GLml2TwMAkB6hEXGFOjnGrB7k4FBEg0MRRz9XPlYsnktIBADABNPTiCvUyTGZ1oPklBoAALyLkUbEFerkmLbWxqQRzFza4PWNNAAAlDtCI+IKdXKMEe4SQ9+ZkYhOnxnL6HN1dvVrU3t3/OPwwHD8Y4IjAADFQWhEXLoRQbuTYzI9ei+1TmTq+sl0nyvx2ulsau9OCpOb1y7K6HUCAIDsERoRl25E0Goa2Dh6z2AcvSfJdkOJ3edKvXYmVq3fL0lqmlOnb93amtVzAQCANUIjkmRzcozV0Xt2odFujWI+x/f1vHVSd3/vv/R3f/oHOV8DAAAkIzQiZ7kevZdJaZ98j+/7nzfC8ZFHQ9OcOq1Zfml+FwYAoEIRGpGzXI/esyrtY4RGs2vno+etkxOCpIEd2QAAWKNOI3KW69F7mZT2KfbxfcaO7Pu2v1zUzwsAQKkgNCJnKxbP1cJPzo6PLPp90sJP2h+9Z1XCZ9X6/bpv+8sTrl0sPW+d1La9R4r7SQEAKAG+WCzm8CRgbsLhQUWdno8sIfX103T8+Cm3m1EU6crtpEpdf5jJc5zi90k/uIPyPYkq6fuz0OhLZ9GfzqI/nVOqfen3+xQKTU17H2saUXSp5XbS6XnrpOVzzAqRO6GC/3YBAMAUoRGuMEr7mG1MkaQ1jxxM2pySWg7I6rkAAMBZrGmEZxmleDq7+tPev3rZRUVuEQAAlYvQCNdksuFkJBLVpvZufWnD/qTHd3b16we7ui2eCQAAnMT0NPJmd7qLmWxOfUk9onDrT3pUqC1cUyfzYwEAQCp+OyIv6U532dTerU3t46OANVUBDY+OpQ2TuWw4MY4oHB4t3G6V4ZGIpNzDMAAA5YjQiLykO90l0fDomKT0RwXmIhqT6RpHp4yOSV++b798Pr/lUYcAAFQS1jQiL9mUvTGOCsyHz6d4eCuk0TGZHnUIAEAlIjQiL1anu6STGDKzfa4kVQV8RSnwbaZQtSEBAPA6QiPy0tbaqOpg5t9GodoadXb1a80jB7MOYE1z6jQScbfydi5BFwCAckBoRF5amhu0csncjMPUjOmTtWXPkbSBccqkgKyOmn77vUFXQ1t10K+21kbXPj8AAG5iIwzylnhSy7a9R9RxuM90Z3Tq8YCGUG2N7rt5vjq7+uM7r1MNDkU06tJIo09SVdCnTe3d2tHRy05qAEDFITTCUSsWz9WKxXMlSTf9a0d897QdY+SxpbnBNDRKyvh6TotJOn3mw53gRlkhv09qnTc7/poBAChXhEYUxLa9R7IOeMZZ01MmBeIBzetSi45T2xEAUK4IjSiIbE57MRi1EOdf3KCfHe7TmLt7XrJy4FCfXuo5puHRqCK/azi1HQEA5YSNMCgIq9NeFn5ytumGlpFIVAcOlVZgNJw+MxYPjAZqOwIAygWhEQXht9gGvWLxXN138/ziNcZl1HYEAJQDpqdREK3zZsfX+iVa+MnZ8X+HamsqIlAljqqy5hEAUKoYaURBrFg8Vws/OTs+4uj3jQfGxF3G2RYGL0WJtR07u/qTalQaax4LfZY2AABOYKQRBZNYficdY4QtceStnEYep04OavmVFyS9TrPzrBltBAB4HaERrkosDC5JX934gk6eHnWxRc4ZGU0OiGaBuJyCMgCgfBEakZX7tr+cdKpL05w6rVl+ad7X7ezq1/Z9r2lwKJL3tbwicRTRago6dSc56x4BAF5EaETGUgOjNH4s4Opv7ddYVDkHnM6ufj2+u2dCuZpyEB4YjodAM4nnWRvrHo1pbGo9AgC8orx3IcBRZudGj/1uFjbXjR3lGhgNm3d1W05BJ4ZBq3WPAAC4iZFGWEqcKs1Eths77tv+clkHRkmWhcpTp6ZZ9wgA8CpGGmEqtURMprJ5vNnoZaW4pDGU9LHZSTlmtwMAUCyERphKN1WaCQJO5g6+2p80nZ+udmVirUcAANzC9DRM5TIlSsDJTup0frralYmbi9hZDQBwC6ERprIttp1LiGmaU1fxU9ThgWGteeRgvO9Sa1ca2FkNAHAT09Mwle0xf/fdPD+r8NLZ1a/3Tgzl0rSyk8nOc3ZWAwDcxEgjTKWbKj0zEtHpM2MTHpvtOsbOrn5t3tVtubO40tjtPM90ZzVT2ACAQiA0wlLqVGnqFKmU+TrGbXuPqONwn6IERVNWywHMlgskBnamsAEAhcL0NLLS0tyglUvmxoNKqLZGK5fMtQ0k2/Ye0YFD5RcYQ7U1Wr3sonh/+H1K+m+2pkwKmN7X1tqoQMp1A77kE2WYwgYAFIpjI41vvvmm1q5dq5MnT6qurk4bNmzQeeed59Tl4SFmGzWsdBzuK1Br3GMENqMvEkf4orHxEdiqoC/tdL6Z02fGkjbFGDq7+vX0c0cnTOf7UtIpxcEBAIXiWGj82te+phtuuEHXXnutfvzjH+uf/umftHXrVqcujyIo5Fq4chthlKTJk4JJ6z7TjfBVV2X/IxYeGNam9m5tau9WqLZGlzSGdPDV/rQ1MyNjsaR1kJlMYQMAkAtHpqfD4bC6u7u1dOlSSdLSpUvV3d2t999/34nLowhST3/J9RxpM7lO13rZ4FAk/m+zkbzEx+QiPDCsA4f6LIusJ35uioMDAArFkZHGd999VzNnzlQgML4eKxAIaMaMGXr33Xd11llnZXSNUGiqE00pafX101z73M/8V2fakbJn/utNXbPgE3lf/6o/nKPdnW/lfR0v8ft9+r/r9+vs6ZM17SNVOvXB6ITH1E+fLEk6XsDSQvXTJ8e/d65ZME210yZp654e/fbEkM6ePll/saRJCz51rp7/5dtpb8/487j4/Vlu6Etn0Z/Ooj+dU2596Znd0+HwoKLlOIeZofr6aTp+/JRrn98s1Bw/MZRRu+ymtv+0tVFDZ0Z14FD5rG00vl+tAuHvnzdd559Tl3bH+fyLG/RKbzjv9Yaf/+zHk75Gzf+nThu+3JL0mP/3/OtJbTh+Ykgb/+OwBk6dyWgJgtvfn+WEvnQW/eks+tM5pdqXfr/PdCDPkdA4a9YsHTt2TGNjYwoEAhobG9N7772nWbNmOXF5FEE+a+EyLfOyYvHciiu580pvWCsWz5UkPf3c0fimGJ8vpl8ceU+DQxFNmRTQ8GhUkRyKVk6ZFFBLc4NtaLfaVU0pHgBAJhxZ0xgKhdTU1KRdu3ZJknbt2qWmpqaMp6bhvnzWwmVT5qWUAqMTyzATg/ho5MMXPzwai693PH1mTLFoTFMnp/8brjroV9OcurS33/C5C9OuR93U3q1V6/drzSMH1dnVz65qAEDeHKvT+PWvf11PPvmkFi9erCeffFL33HOPU5dGEeRaf1HKrsxLKezinTIpoNXLLpIT+dZ4vemCdaKxmFRTFdDmtYuS6j4aX4c1yy9Ne3tLc4PltY1RX7NAWgpfDwCANzi2prGxsVE//OEPnbocXJBL/UUp86ntzq5+DY9mXrOwaU6det46mXV7clVT5dP3/mFh/GNjujdXiSO1mVzHeIzZ18Hsdrtrj0Siqgr6VB3053SSDwAAEifCwAGZTG0bU6jZlKD57CWz5fcVr1bP8Gjy2GK61yWNjwhm0qrEkdpMRvRyHfXL5Hmnz4xp/sUNOY0kAwAgeWj3NEpXYoHrxI0YknTLgx1ZnYiSaPu+1xSNubcI0nhdiRtYJGl4dEzBgE81VX7b17bmkYMKDwxr6uSgAj5NONHFkM+o3yWNoYx2pR98tZ+gCADImS8Wc/G3cgJK7pTm1nwznV392ryr2zQkednUyUHFYjGdPjMmv898844xapduenjKpIBGI7Gk6WC/z2caghd+cnZ8l7WZdDukJU0o52NnyqSAbvjchVmFx3L7/nQTfeks+tNZ9KdzSrUvC15yB0i1o6O3JAOjlHyKi9XfMeGBYa1edlHa0PbB8JhS86HVqOkrvWHLNpmVNaoK+rIKjNL4VPUP2ru1fd9rGhyKOH5kJACgPBEa4ajE0bB8TZkUyHlquxhCtTWmU9jZjt/b9dfTzx1NW9ZoJMdTCmP6MByb1dUEACARoRFZsSoinToalq8Phr0bGKXxtYSS4mVv8gm4VptZOrv6s752uulxKyORqLbve82yQDgAoLIRGpExu5Nf7GoRZiuf1baTqgM6M1LY0Hnw1X6df06dWpobHCvNk066IumGqZODGhmNTiilc8PnLpQkPbarO+OC6oNDkbSjj9L42eTHTwwpVFujSxpD8eMPCZcAUDkIjciY3VF0XjpdpNCBUUp+7Wa1Kq020hjsdjRb9evyKy+QNHHneuL1Ht/dk9MRhSORqDa1dyft+g4PDCft1GZqGwAqB6ERGbM7+cUsOJUz4/W2tTZOmJqvDvrjgdAovZMqcV1kOp1d/ab3TZ0cjD/X7BrG7caml1zY5U3OsAaAykBoRMbsTn5JF5zKnfHa09WqvKQxpB0dvdrU3q0pkwIKBnxJI36Z1Ga0mppefuUFpmV4Um/77t9dHn/eqvX7c369ZirtjwUAqESERmTMbDTNCCqpwSmTqdlSZ2yGkZKP+Utd/3n6zJgCvvHRwWzK3NiFsdQ1ppt3dcvn/zCcpps+9vnyWy+aDmdYA0D5IzQiY2YnvyQGn9TzkUu5yLfBCHrpmNVXTLf+cyw2fgRh4qifHavRXbPPkdrZidPHnV394/V2HMQZ1gBQGQiNyEpqKEwndco0GAxobLS45XNqqvwaHnVmmtxqLWB4YDjtFLHd+s9MWY3ubmrvzvg6xufd0dHrSGY0amiyexoAKgehEY5KHVl0a62bU4HRzpRJgbRliMwKk2c7jWs1uptNEXWrIw8NTXPq1PPWyYyuN6k6qI1/35rRYwEA5YHQCEc9/dzRkp6KzkZ10C+fz6eRSHI4HIlEVV0VVHXQb7r+Mxtmo7vpRiEDPiWtaUz9vFbT3WuWX6r7tr+cUXBk4wsAVB6/2w1AefHysX9Oqwr6TKeuB4ciWrlkbnyEL1RbY1uPMVstzQ0TPseqpRfpxqubTD9vW2ujqoPJP/aJoXLN8ku1ee0i28/NxhcAqDyMNAI5sgrIRv3FQq/1M/scdnUb7Y4LtKq5aTVianXMJACgtBEa4SirncaVwuu7iTMJs2Y1N6dMCuiGz12Y9vl2x0wCAEoboRGOWn7lBVnt6i0XRk1Kv0+af3HhRxgLLXVEsn76ZH3+sx+3fF1PP3fU8phJAEBpIzTCUS3NDdqyp0cjkQrZDfM7RhHzaEw6cKhPBw71leT0rNn0cn39NB0/fsryeWbT9WyaAYDyQGiE46qrAhqJVPYUteTc9Gyx1glaTS9fs2Ca5XOtjjsM1dZo294j6jjcFx+NbZ03WysWz3Wu8QCAgiM0IiOppVia5tRpzfJL0z620tc0Jsp3eraY6wTTnTBjtP+aBZ+wfK7VaGJ4YFgHDvXFPzZGYyURHFFUbNQC8kNohK10tft63jqpuzd1at3qlgmPt9p5W4nCA8O65cGO+PTt1MlBLb/ygox+WVkFOad/2eVzik0uX3NjGr+mKqC/uCr95hrAKWzUAvJHnUbYMiv23Bce0q3f+dn4ecYJLmkMFaFVpSVxvd/gUESb2ru1av3+tP2XyKnjCDNhVnsxVFuj53/5ttY8clCr1u/XmkcOTmhzuvqPmRoeHdNju3os+wHIl9UfYAAyQ2hEXgaHInp894e/8Du7+nXwVX75Zyq1/1JZBTmnmRX+vqQxpId++D/xoGqM0CS2ObXQeLaisRi/vFFQxfwDDChXTE8jb5GxmDa1d2tHR69OnhqumGMEnZLYf6lrrNLVSyxEHUhjrddIJBovH2Ss+drR0avh0YlHJaZOkSfWf1zzyMGsfxmHB4Z163d+plgsptNnxlhzBkdZHaEJIDOERjiGv9jzk26NVaYnuOQjda1XNPZhMG1pbjCtu5n69U7cZDB1clABn7L+AyJxExVrzuCkYv0BBpQzQiPgISORqB7bNR7SEoNjIUOT3WabTEZoUoPn4FBEwYBPU6r8SaOGb/zmZNJOajsUB4dTivEHGFDuCI2wtXntIq1av9/tZlSMaEzavKtb2/e9psGhSMF/udmt9WprbdTWnxxNmqJOHaFJFzwjYzF9dEpQG/++NX6b8RqyCY5GOyiXgnwV4zx4oJyxEQYZ2bx2kWaHJrvdjJI1ZVJAUyYFMn78WOzDqdrwwLA2tXfrpn89UJAdxmZruvy+8aDW0tygv/3CH8QfF6qt0colc5N++WazyWDF4rnavHaRNq9dlNF6slBtTXwk02ozDgCgsAiNyNi61S0Exxw0zanTxr9vNT1mL1PDozHLnda5MiuXE40pHswWfOpc3XfzfG1eu0j33Tx/wmhNrru87Ur1GCOaZlPo2/e9Znl9AIBzCI3IyrrVLdq8dpGa5tS53ZSS0fPWSW3beySrkUYzkbGY40HJKJfj9028L9M6dmbleuw2GaSW6pk6ORjvp8QRTbORzMGhCKONAFAkrGlETtYsv1Tb9h7Jam1aJRs/+SRNKsvB4FAkvsY0m9NlrGSzS9rs+VJumwxS15klrl00AqtRBigdNsoAQHEQGpEz49xggmNmhkedL2BpFAeX8i9Lk28dOyc2GZgd9WYWGI3HAAAKj9CIvKxYPJfQ6LLIWMxytC3TXcdeqGNntnbRaqTR2Cjz9HNHczrfGwCQGUIj8jY7NFl94SG3m1HRwgPD+tKG/YrGlHSiyyWNIR18tX/CyJ00cWTSC3XszEYNozEpGPApklItPOAbP+t8867upELiTo7AAgDGERqRt3WrW6jj6AHGSJzx3/DAcNpRYKuC2W7WsbPa0GIE4OcP9yn2u9dXHfRp5ZIm7ejoTXvyjN0ILAAgO+yehiM2r12kqvw3B5e8qZODJXGWrRfXAVrt0jZGTGNJ4XB8Y5HVa/Hi6wSAUkVohGO+v2aR201w3fIrL9B9N8/X6mUXKeDMZumC8GKwtQp4r/SGTY86tHotXnydAFCqCI1wVKXXb0w8L3rV0ouSTlHxUt9c0hhyuwkTWBUItzpxpq21MW1ADwZ8Rd3EAwDlzheLxZyvA5KDcHhQUau6GmWuvn6ajh8/5XYzHHHf9pfV89ZJt5vhiropVbr/lstM7/dS3yRumLHb8FKM78/UcjvS+O7tlUvmxjfnpArV1ui+m+dntXva7TOsy+ln3QvoT2fRn84p1b70+30KhaamvY/Q6BGl+s1lZzwI9GgkUnlf24WfnB2vZZmos6tfW3/SU5C6jfnw+aQF89K3uVjfn2aBzipQZhP4nLpOPsr1Z90t9Kez6E/nlGpfWoVGdk+joMx243514ws6eXrUhRYVz4FDfXr+UJ8+Mimg02fGkkKQ0SdeOlUnFvuwUHu64FgMZt8vTpUDMqsDyS5rALBHaIQr7r/lMm3be0Qdh/ssT/sodTEpPmWarkbiisVztWLx3KQRtmwZ5Whe6Q1nNEJn5/nDfa6FRitOlAOyWhsJALBGaIRrEgPT47t7JhRuLkcjkaiefu5o2sLaxm1rHjmYcYgx1vSZMa5pdq50OrHYh20wAug1C6Zl/PxMuLWuMJOjEt1e8wgAXsXuabiupblBN17dlLTTePWyi1xuVeGcPjOmbXuPmN7f1tqo6mBmP5qZhMuW5oasS88Y1zVGR5//5dtZPd+KMfqZ+jmsins7JV3fJh6V6GbbAMDrGGmEJ6SbemxpbtDf3P+8hkYyn1otFVZrB9Ot3zszEolPcyfKNAy2tTZOOGovUyORqLbu6dGGL7dk/+Q0nF5XmM3IYGrf+n0ffu5CtA0AygmhEZ728FcX6O5NnWV5tvWBQ33x8Ji60zo1RJvt+s20DqFxrcSyNNk4fmJItzzYMWFDTy6cXFeY2i9WZ2sbjNvTPc9s7SdrHgGA0IgSsG518giXl3YcO+XAoT797H/6NBZNXzfRid3DRhDN9Zxwqw092chkXWGmch0ZNHueUbvSibYBQLkhNKLkGBto0oWfzWvHjzLMJhhNnRxULBaLj6Jd0hjS84f7VOwKpmO/yzBmocyJ3cPS+OsdHIrkdY2RSFSP7erWpvburANsW2tjXqOmiXIdtTS7Pxobb4sTbQOAckNoRMkyAmKu/D7pB3ekv8ZLPcdymsZ1SiHX0S2/8oKsdlObMUbkwgPD2tTerTd+czKjUj1O1VyUch+1tHpeW2sju6cBIA1CIypW67zZpvflGxhXL7tI2/e9lteIXnhgeELpGyfCS0tzgyOhMdWBQ316qeeYbvjchbbtdGrUNNdRS6vnOdU2ACg3hEaUpfZ/vVbL/uHHae/z+8YDo9WomNlIVKZSg0eum3lSS78Y186X1RT1lN+dYJOL02fGshp1zFeuo5ZOjnYCQKXg7GmPKNUzKr0q3/7s7OpPW6ImGPDpxqub9MZvTppuxjE7c9qJDTxTJwf13b+7PK9rSEpbUN14bflslknkk7TApC9KRSEKffOz7iz601n0p3NKtS+tzp6muDeQRktzgyZPmjgQHxmLaUdHr1YsnquFn5w4vW0WGKXxDTz5Fi0fHIro1u/8LO9i0+kKqhuB0fg4XzGNT1nf9K8HSrI4NoW+ASAZI40eUap/kXiVE/1pNdqW7yYcp0Ydl195QUGmVK3OrJ46OahzZ0xVz1snM75eddCvlUvmltT0r9lxjlMnB1VTFch59JGfdWfRn86iP51Tqn1pNdLImkbAhJP1BFMlnrttTH9ma3Ao4ug6x0Spa/7qp0/W5z/78QkFxzPd7DMSiWpTe3d8A04hA282rKafzb4mg0OR+Gt2eq0pAHgZoREw4WQ9QTOJG2YSA4xZkelUhSzNk9i2dH8xG/fnMmo6OBTR47t74tdxg91pMpluhuKYQQCVgtAImCj2DtvUAJlpWRy3j7hbsXiuzj+nTlt/0qPh0cyXmBjrQ4sdtqxGdxMDYLo/Gsy4/TUAgGIgNAIW3KrZ19LcYLlDO5EXjrhLHHV8/lCfMo2O4YFhrVq/Pz6yWuhgbrVWM7FNUvo/Gs6MRNKWI/LC1wAACo3QCHiUMYJntebRa0fcGW3Otnh4rqfLZCvdmdOpEgNg6h8N6UKn174GAFAohEbAw9KFFi8XpDZCVb4OHOrTwVff1colTY6+PrtpZLsASFFwAJWM0AiUkGyny4sdMjMZycvUSCSmzbvGRyydarPV5pZsTpMhJAKoRIRGoEzZ7Q4uBKc3hIzFpE3t3Xr6uaMZnWltx2xHfKnVkAQAN3AiDFCm0o36GbuDC8VsQ8jUycGk02eqg76srnv6zJg27+p25CSclUvmJrWFwAgAmWGkEShTZqN+hSwPYzaSl1rIO5ezrcdicqRETzlML3t9bSuA8pT3SOOPf/xjLVu2TBdddJGefPJJJ9oEwAFmo36FLA+T6UjelEmBnK5PPUTOxAbgnrxHGpuamvTAAw/o0UcfdaI9ABxSjBNt0rEbyevs6tfwaG6bZaiHaL3sgNFGAIWUd2i84IILJEl+P8sjAS/xanmYHR29ioxlfnKMIeAT9RDlzrIDAJA8tKYxFJrqdhNcV18/ze0mlBX6U7pmwTRds+ATjlzLqf58P4dwU1Pl199+YZ4WfOpcR9rgtnz6sn76ZB0/MZT29kr9nq/U110o9Kdzyq0vbUPjddddp76+9EeZvfjiiwoEclublCocHlQ0mv3oQ7mor5+m48dPud2MskF/OsvJ/jzLolZiqimTAkmldlLbUIobQvLty89/9uNplx18/rMfr8jveX7WnUV/OqdU+9Lv95kO5NmGxp07dzreIACVy2yt5fyLG/RKb3hCAOzs6teaRw6mvT21DuUP2rv1g13disUkv09qnTe7IMcRusmryw4AlD/PTE8DqAzZhB6rAuXpNoTE4v83fp71gUPjsyTlGBwJiQCKLe/QuGvXLn3rW9/SwMCAfvrTn+rRRx/V5s2bdf755zvRPgBlKNPQY7VTONMp7o7DfWUXGgHADXmHxqVLl2rp0qVOtAUAkljtFLY6RzpRBS+VBgBHUScHgGdZFShva21UddD+Lcyf3YmFAAAThEYAnpUuGBoFylNPnzE7z7p13uyCtxMAKgEbYQB4lt2mmdS1kdv2HlHH4T5Fy3j3NAC4hdAIwNOy2Sm8YvHcrEJiKdZ5BAC3EBoBVCSrcj4ERwCYiNAIoCJZlfMp9dDICCqAQiA0AqhIVuV8ShkjqAAKhd3TACqSVTmfUmY1ggoA+SA0AqhIVuV8Slm5jqACcB/T0wAqVlXQp5HI+L+nTg5q+ZUXeG4KN9v1iWYn5ZT6CCoA9zHSCKDiGOv+Tp8Zi982Mhq1eIY7jHYaIdBYn9jZ1W/6nHIdQQXgPkIjgIpTKuv+cmln6kk5odoarVwy13MjqABKD9PTACpOqaz7s2rnmkcOmk5ZZ1MQHQAyRWgEUHHs1v15pc6hWTslTZiyliipA6CwmJ4GUHGs1v3lso6wmO1Mx4tT6wDKD6ERQMWxWvfnpfWO6dppxmtT6wDKD9PTACqS2bo/r613TG2nsZYxFSV1ABQaI40AkMDrJ8VQUgeAWwiNAJDA66GMkjoA3ML0NAAkMMKXF3ZPm6GkDgA3EBoBIEUlhzKvlBsC4D2ERgCApA+PLTR2j1MDEkAi1jQCACSVzvGKANxBaAQASPJeuSEA3kJoBABI8n65IQDuYk0jAJQBJzawtLU2Jq1plLxVbgiAuwiNAFDinNrAUgrlhgC4h9AIACXOagNLpoEvdaRy9bKLCIsAkhAaAaDE5buBhVI7ADLBRhgAKHH5bmCh1A6ATBAaAaDE5XteNqV2AGSC6WkA8IB8dj/nu4ElVFuTNiBSagdAIkIjALjMiTWF+ZyXTakdAJlgehoAXOb2msKW5gatXDI3PrIYqq3RyiVz2QQDIAkjjQDgMi+sKcxnpBJAZSA0AoDLirGm0IkTYwBUNqanAcBl+e5+tmOsmTSCqbFmsrOr35HrA6gMhEYAcFmh1xS6vWYSQHlgehoAPKCQawq9sGYSQOljpBEAyly+J8YAgERoBICyV+g1kwAqA9PTAFDm8j0xBgAkQiMAVATqMALIF9PTAAAAsEVoBAAAgC1CIwAAAGyxphEAUDQcZwiULkIjAKAojOMMjdNpjOMMJREcgRLA9DQAoCjMjjN8+rmjLrUIQDYIjQCAojA7tvD0mTF1dvUXuTUAskVoBAAUhdWxhTs6eovYEgC5IDQCAIrC6thCs1FIAN5BaAQAFEVLc4OmTk6//9JqFBKANxAaAQBFs/zKC1QdTP7VUx30W45CAvAGSu4AAHKSS81F435qNQKlh9AIAMhaPjUXW5obCIlACSI0AgCyZlZzcUdHr2kgLNRpMJwyUzn4WruL0AgAyJrZbud0t3d29Wv7vtc0OBRJepwTp8E8/8u3OWWmQnCikPvYCAMAyJrZbufU241f9ImB0WCMTOZj654e0xFPlBer0W0UB6ERAJC1ttbGjHZBp/tFnyjf+oy/PTFUkOvCe7IZ3UZhEBoBAFlraW7QyiVz4yOLodoarVwyd8I0od0v9HzrM549fXJBrgvvyXR0G4XDmkYAQE4y2QUdqq0xDY5O1Gf8iyVN2vgfh5NGM4MBn86MRLRq/X42S5SRttbGpDWNEjU+i42RRgBAwaSbxpakKZMCaUcms7XgU+cmjXhOnRxULBrT6TNjkj7cLNHZ1Z/X54H7Mh3dRuEw0ggAKJhiFPNOHPFc88jBCZtu7EoBoXRQ49NdhEYAQEEV8xc9myWAwmF6GgBQNtgsARRO3qHxnnvu0VVXXaVrrrlG119/vV599VUn2gUAQNYyLQUEIHt5T09ffvnl+sd//EdVVVXpwIED+spXvqJ9+/Y50TYAALJSjDWUQKXKOzQuXLgw/u958+apv79f0WhUfj8z3wCA4mOzBFAYvlgsFnPqYg899JCOHDmihx56yKlLAgAAwANsRxqvu+469fX1pb3vxRdfVCAQkCQ9++yzam9v11NPPZVTQ8LhQUWjjuXXklNfP03Hj59yuxllg/50Fv3pHPrSWfSns+hP55RqX/r9PoVCU9PeZxsad+7cafsJnnvuOT3wwAN64okndPbZZ2ffQgAAAHha3msaDxw4oG9+85t6/PHHdc455zjRJgAAAHhM3qHxzjvvVFVVlW699db4bU888YSmT5+e76UBAADgEXmHxp///OdOtAMAAAAeRl0cAAAA2CI0AgAAwBahEQAAALYIjQAAALBFaAQAAIAtQiMAAABsERoBAABgi9AIAAAAW4RGAAAA2CI0AgAAwBahEQAAALYIjQAAALBFaAQAAIAtQiMAAABsERoBAABgi9AIAAAAW4RGAAAA2Aq63QAAADCus6tfOzp6FR4YVqi2Rm2tjWppbnC7WYAkQiMAAJ7Q2dWvLXuOaCQSlSSFB4a1Zc8RSSI4whOYngYAwAN2dPTGA6NhJBLVjo5el1oEJCM0AgDgAeGB4axuB4qN0AgAgAeEamuyuh0oNkIjAAAe0NbaqOpg8q/l6qBfba2NLrUISMZGGAAAPMDY7MLuaXgVoREAAI9oaW4gJMKzmJ4GAACALUIjAAAAbBEaAQAAYIvQCAAAAFuERgAAANgiNAIAAMAWoREAAAC2CI0AAACwRXFvAABK2Fc3vqCTp0fjH9dNqdL9t1zmYotQrhhpBACgRKUGRkk6eXpUX934gkstQjkjNAIAUKJSA6Pd7UA+CI0AAACwRWgEAACALUIjAAAlqm5KVVa3A/kgNAIAUKLuv+WyCQGR3dMoFEruAABQwgiIKBZGGgEAAGCL0AgAAABbhEYAAADYIjQCAADAFqERAAAAtgiNAAAAsEVoBAAAgC1CIwAAAGwRGgEAAGCL0AgAAABbhEYAAADYIjQCAADAFqERAAAAtgiNAAAAsEVoBAAAgC1CIwAAAGwRGgEAAGAr6HYDAACA93R29WtHR6/CA8MK1daorbVRLc0NbjcLLiI0AgCAJJ1d/dqy54hGIlFJUnhgWFv2HJEkgmMFY3oaAAAk2dHRGw+MhpFIVDs6el1qEbyA0AgAAJKEB4azuh2VgdAIAACShGprsrodlYHQCAAAkrS1Nqo6mBwRqoN+tbU2utQieAEbYQAAQBJjswu7p5GI0AgAACZoaW4gJCJJ3qHxe9/7nnbv3q1AIKBYLKYvf/nLuvrqq51oGwAAADwi79D4xS9+UTfddJMk6dixY1qyZInmz5+vj370o3k3DgAAAN6Q90aYadOmxf/9wQcfyOfzKRqNWjwDAAAApcYXi8Vi+V5k+/bt2rJli/r7+/WNb3yD6WkAAIAyYxsar7vuOvX19aW978UXX1QgEIh/fPToUd12223aunWrpk+fnlVDwuFBRaN559eSVV8/TcePn3K7GWWD/nQW/ekc+tJZ9Kez6E/nlGpf+v0+hUJT095nu6Zx586dGX+iCy+8UDNmzNBLL72kxYsXZ95CAAAAeFreaxrfeOON+L/ffvtt9fT06Pzzz8/3sgAAAPCQvHdPb9y4UW+88YaCwaACgYDuvvtuNTZSMR4AAKCc5B0av/Od7zjRDgAAAHgYZ08DAADAFqERAAAAtgiNAAAAsEVoBAAAgK28N8IAAAAgc51d/drR0avwwLBCtTVqa21US3OD282yRWgEAAAoks6ufm3Zc0QjkagkKTwwrC17jkiS54Mj09MAAABFsqOjNx4YDSORqHZ09LrUoswRGgEAAIokPDCc1e1eQmgEAAAoklBtTVa3ewmhEQAAoEjaWhtVHUyOX9VBv9pavX8EMxthAAAAisTY7JLJ7mmv7bImNAIAABRRS3ODbfjz4i5rpqcBAAA8xou7rAmNAAAAHuPFXdaERgAAAI/x4i5rQiMAAIDHeHGXNRthAAAAPCabXdbFQmgEAADwoEx2WRcT09MAAACwRWgEAACALUIjAAAAbBEaAQAAYIvQCAAAAFuERgAAANgiNAIAAMAWoREAAAC2CI0AAACwRWgEAACALUIjAAAAbBEaAQAAYIvQCAAAAFtBtxtg8Pt9bjfBdfSBs+hPZ9GfzqEvnUV/Oov+dE4p9qVVm32xWCxWxLYAAACgBDE9DQAAAFuERgAAANgiNAIAAMAWoREAAAC2CI0AAACwRWgEAACALUIjAAAAbBEaAQAAYIvQCAAAAFuERgAAANjyzNnTleaee+5RZ2enqqur9ZGPfER33XWXLr744gmP27Fjh77xjW/oYx/7mCTpnHPO0cMPP1zs5nrSm2++qbVr1+rkyZOqq6vThg0bdN555yU9ZmxsTOvWrdMLL7wgn8+nv/qrv9IXvvAFdxrsYSdOnNDtt9+uX//616qurtacOXN077336qyzzkp63Nq1a/Xiiy9q+vTpkqSrrrpKN910kxtN9rRFixapurpaNTU1kqTbbrtNl112WdJjhoaGdOedd6qrq0uBQEB33HGHFi5c6EZzPe03v/mN/uZv/ib+8alTpzQ4OKiXXnop6XEbN27U008/rRkzZkiSLr30Un3ta18ralu9asOGDdq7d6/eeecdtbe364ILLpCU2XuoxPtoonR9men7p1QG76ExuGL//v2xkZGR+L+vuOKKtI/70Y9+FLvllluK2bSSsWLFitgzzzwTi8VisWeeeSa2YsWKCY/ZuXNnbNWqVbGxsbFYOByOXXbZZbG333672E31vBMnTsR+/vOfxz9ev3597M4775zwuDvuuCO2bdu2YjatJC1cuDB29OhRy8ds3Lgxdtddd8VisVjszTffjP3RH/1RbHBwsBjNK2nr1q2L3XPPPRNu/+53vxtbv369Cy3yvl/84hexvr6+Cd+XmbyHxmK8jyZK15eZvn/GYqX/Hsr0tEsWLlyoqqoqSdK8efPU39+vaDTqcqtKRzgcVnd3t5YuXSpJWrp0qbq7u/X+++8nPW737t36whe+IL/fr7POOktXXnmlfvKTn7jRZE+rq6vTZz7zmfjH8+bNU19fn4stKn979uzRn/3Zn0mSzjvvPP3+7/++fvazn7ncKm8bGRlRe3u7/uRP/sTtppSUT3/605o1a1bSbZm+h0q8jyZK15eV9P5JaPSAp556SgsWLJDfn/7L8dJLL+naa6/Vn//5n+v5558vbuM86t1339XMmTMVCAQkSYFAQDNmzNC777474XGzZ8+Ofzxr1iz19/cXta2lJhqNavv27Vq0aFHa+x9//HEtW7ZMN998s3p7e4vcutJx2223admyZfr617+ugYGBCff39fXFl51IfG9mYv/+/Zo5c6aam5vT3v/ss89q2bJlWrVqlQ4dOlTk1pWWTN9DjcfyPpoZu/dPqbTfQ1nTWCDXXXed6V8aL774YvwH9dlnn1V7e7ueeuqptI9dsGCBrr76ak2aNEnd3d1avXq1tm7dqsbGxoK1HZXtn//5n/WRj3xEX/ziFyfc95WvfEX19fXy+/165pln9KUvfUn79u2Lfz9j3FNPPaVZs2ZpZGRE//Iv/6J7771X3/72t91uVsn70Y9+ZDrKeP311+uv//qvVVVVpYMHD+rmm2/W7t2742vHgGKwev+USv89lJHGAtm5c6f++7//O+3/jG+O5557Tg888IAee+wxnX322Wmvc9ZZZ2nSpEmSpIsuukiXXnqpXnnllaK9Dq+aNWuWjh07prGxMUnjC7Xfe++9CdMGs2bNSgrv7777rhoaGora1lKyYcMGvfXWW3rwwQfTjnzPnDkzfvvnP/95ffDBB4w4pGF8H1ZXV+uGG27Qyy+/POExs2fP1jvvvBP/mO9Na8eOHdMvfvELLVu2LO399fX18SU/8+fP16xZs/T6668Xs4klJdP3UOOxvI/as3v/lEr/PZTQ6JIDBw7om9/8ph577DGdc845po87duxY/N/vvPOODh8+rAsvvLAYTfS0UCikpqYm7dq1S5K0a9cuNTU1TditdtVVV+mHP/yhotGo3n//fe3bt0+LFy92o8med//99+tXv/qVHn74YVVXV6d9TOL34wsvvCC/36+ZM2cWq4kl4YMPPtCpU6ckSbFYTLt371ZTU9OEx1111VX693//d0nS//7v/+rVV1+dsMMaH9q5c6daW1tNRw4Tvzd7enr0zjvv6OMf/3ixmldyMn0PlXgfzUQm759S6b+H+mKxWMztRlSiP/zDP1RVVVXSD+gTTzyh6dOn66677tKiRYt0xRVX6P7779dPf/rT+OjkjTfeqOuuu86tZntKb2+v1q5dq4GBAdXW1mrDhg36vd/7Pa1evVq33nqrLr74Yo2Njenee+/VwYMHJUmrV6+Obz7Ah15//XUtXbpU5513Xnxk2yjvdO211+rRRx/VzJkz9Zd/+ZcKh8Py+XyaOnWqbr/9ds2bN8/dxnvM22+/rVtuuUVjY2OKRqNqbGzU3XffrRkzZiT15QcffKC1a9eqp6dHfr9fa9as0ZVXXul28z1r8eLFuuuuu3T55ZfHb0v8Wb/jjjvU1dUlv9+vqqoq3XrrrWptbXWxxd6xbt06/ed//qd++9vfavr06aqrq9Ozzz5r+h4qifdRE+n68sEHHzR9/5RUVu+hhEYAAADYYnoaAAAAtgiNAAAAsEVoBAAAgC1CIwAAAGwRGgEAAGCL0AgAAABbhEYAAADY+v9C92cUuaPfOAAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAo0AAAHUCAYAAABfxBLvAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/d3fzzAAAACXBIWXMAAAsTAAALEwEAmpwYAAA4PUlEQVR4nO3df3RU9Z3/8df8SAIFsuAYCFS/2I0VQqqLtud0s1QDqAfpglZ2e1bZUrd8y3Zrv7rbfkVx9Wyry7ZQu9oWdbeyooDK2e0p2G8QykrB1MV09VT8avMDNce11hCkI3wDGBIyM98/2DvOTO6de2fmztw7M8/HOR7JZObOZz5JJq98frw/gUQikRAAAACQRdDrBgAAAMD/CI0AAACwRWgEAACALUIjAAAAbBEaAQAAYIvQCAAAAFthrxtgOHbslOLx6q3+E4lMVDR60utmVAz60130p3voS3fRn+6iP91Trn0ZDAY0ZcoE08/5JjTG44mqDo2Sqv71u43+dBf96R760l30p7voT/dUWl8yPQ0AAABbhEYAAADYIjQCAADAFqERAAAAtgiNAAAAsEVoBAAAgC1CIwAAAGwRGgEAAGCL0AgAAABbhEYAAADYIjQCAADAFqERAAAAtgiNAAAAsEVoBAAAgK2w1w0AKkVn14C2d/QpOjisSH2dlrU1qbWl0etmAQDgCkIj4ILOrgFt3t2rkdG4JCk6OKzNu3slieAIAKgIroTGY8eO6fbbb9dvfvMb1dbWaubMmbr33nt1zjnnuHF5wPe2d/QlA6NhZDSu7R19hEYAQEVwZU1jIBDQl7/8Ze3Zs0ft7e06//zz9b3vfc+NSwNlITo4nNPtAACUG1dC4+TJk/XpT386+fHcuXPV39/vxqWBshCpr8vpdgAAyo3ru6fj8bi2bdumhQsXun1pwLeWtTWpNpz+41QbDmpZW5NHLQIAwF2BRCKRcPOC99xzj44cOaIHH3xQwSAVfVA9nvvVO9qyu0e/Ozakc6eM1xcXN2v+J8/3ulkAALjC1dC4fv16HTp0SP/8z/+s2tranB4bjZ5UPO5qfi0rDQ2TdPToCa+bUTHoT3fRn+6hL91Ff7qL/nRPufZlMBhQJDLR9HOuldy5//779etf/1qPPPJIzoERAAAA/uZKaHzjjTf0ox/9SBdccIFuuOEGSdJ5552nhx56yI3LAwAAwGOuhMaPf/zjOnTokBuXAgAAgA+xUwUAAAC2OEYQKNDKdfvG3LZpDSWnAACVhZFGoABmgTHb7QAAlCtCIwAAAGwRGgEAAGCL0AgAAABbhEYAAADYIjQCBbDaJc3uaQBApaHkDlAgAiIAoBow0ggAAABbhEYAAADYIjQCAADAFqERAAAAtgiNAAAAsEVoBAAAgC1CIwAAAGwRGgEAAGCL0AgAAABbhEYAAADYIjQCAADAFqERAAAAtgiNAAAAsEVoBAAAgC1CIwAAAGwRGgEAAGCL0AgAAABbYa8bAJSbr9y3T2diH35cE5J+tHqhdw0CAKAEGGkEcpAZGCXpTOzs7QAAVDJCI5CDzMBodzsAAJWC0AgAAABbhEYAAADYIjQCOagJ5XY7AACVgtAI5OBHqxeOCYjsngYAVANK7gA5IiACAKoRI40AAACwRWgEAACALUIjAAAAbBEaAQAAYIvQCAAAAFuERgAAANgiNAIAAMAWdRoBBzq7BrS9o0/RwWFF6uu0rK1JrS2NXjcLAICSITQCNjq7BrR5d69GRuOSpOjgsDbv7pUkgiMAoGowPQ3Y2N7RlwyMhpHRuLZ39HnUIgAASo/QCNiIDg7ndDsAAJWI0AjYiNTX5XQ7AACViNAI2FjW1qTacPqPSm04qGVtTR61CACA0mMjDGDD2OzC7mkAQDUjNAIOtLY0EhIBAFWN6WkAAADYIjQCAADAVlVNT3OqBwAAQH6qJjRyqgcAAED+qmZ6mlM9AAAA8lc1oZFTPQAAAPJXNaGRUz0AAADyVzWhkVM9AAAA8lc1G2E41QMAACB/VRMaJU71AAAAyFfVTE8DAAAgf4RGAAAA2CI0AgAAwBahEQAAALYIjQAAALBFaAQAAIAtQiMAAABsuRYa169fr4ULF2rWrFl6/fXX3bosAAAAfMC10HjllVfqySef1Ec/+lG3LgkAAACfcO1EmE996lNuXQoAAAA+w5pGAAAA2PLN2dORyESvm+C5hoZJXjehotCf7qI/3UNfuov+dBf96Z5K60vfhMZo9KTi8YTXzfBMQ8MkHT16wutmVAz60130p3voS3fRn+6iP91Trn0ZDAYsB/KYngYAAIAt10Lj2rVrdcUVV2hgYEBf+tKX9Md//MduXRoAAAAec216+u6779bdd9/t1uUAAADgI0xPAwAAwBahEQAAALYIjQAAALBFaAQAAIAtQiMAAABsERoBAABgi9AIAAAAW4RGAAAA2CI0AgAAwBahEQAAALZcO0YQ/tbZNaDtHX2KDg4rUl+nZW1Nam1p9LpZAACgTBAaq0Bn14A27+7VyGhckhQdHNbm3b2SRHAEAACOMD1dBbZ39CUDo2FkNK7tHX0etQgAAJQbRhqrQHRwOKfbq9XWPb3qeKVf8YQUDEhtc2doxaLZXjcLAABfYKSxCkTq63K6vRpt3dOr/QfPBkZJiiek/Qf7tXVPr7cNAwDAJwiNVWBZW5Nqw+lf6tpwUMvamjxqkf90vNKf0+0AAFQbpqergLHZhd3T1owRRqe3AwBQbQiNVaK1pZGQmEUwYB4Qg4HStwUAAD8iNKIk/F4nsm3uDO0/OHYqum3uDA9aAwCA/xAaUXTlUCfS2CXN7mkAAMwRGpGmGCOCVnUit+193VejjysWzSYkAgBggdCIpGKNCFrVgzw5NKqTQ6OuPhcAACgOSu4gqVgnxzitB8kpNQAA+BcjjUgq1skxy9qa0kYw82mD3zfSAABQ6QiNSIrU15mGtkJPjjGrE3l6ZFSnTsccPVdn14A2tncnP44ODic/JjgCAFAahEYkmY0I2p0c4/S85sw6kZnrJ82eK/XaZja2d6eFyU1rFjp6nQAAIHeERiTlenKMcV6zwTivWZLtLmS758q8thMr1+2TJDXPnKzv3tqW02MBAEB2hEakyeXkmGznNduFRrs1ioWc+dzz9nHd/U//oZEzMfW8fTx5e/PMyVp942V5XxcAgGrG7mnkLd/zmo2paWP9pFFup7NrwPE17PzfN6NpgVE6Gybv2/ZyYRcGAKBKMdKIvOV7XnO20j7GaKPVtQvV8/bx5DR2KnZkAwCQHSONyJvVucx25zU7Ke1T6jOfjR3ZjEQCAGCO0Ii8rVg0WwsunZEcWQwGpAWX2p/XnK2Ez8p1+3TftpfHXLtUet4+rq17ekv7pAAAlIFAIpEowiRg7qLRk4oXYz6yTDQ0TNLRoye8bkZJmJXbyZS5acXJY9wSDEj/cgfle1JV0/dnsdGX7qI/3UV/uqdc+zIYDCgSmWj6OdY0ouQyy+2YydzEYlaip9CTaqxU8d8uAABYIjTCE0ZpH7NNKYbVDx9I25ySWQ4o22MBAIC7WNMI3zIrxZNq1dI5JW4RAADVi9AIzzjZcDIyGtfG9m59ef2+tPt3dg3o0Z09xWweAABIwfQ0CmZ3uouVXE59yTyicMvPDilepD1cE8aFinJdAADKGaERBcnc1WzUO9zY3i1JqqsJafhMzDRM5rPhxDiicPhMzJX2mxn572vnG4YBAKhEhEYUxOx0l1RGuDPWJ0oqKHjFE7Jc4+iWMzHpK/ftUyAQTAvDbrQfAIByxZpGFCSXsjfGUYGFMsJbMZ2JyfKoQwAAqhGhEQXJdrqLmdSQmetjpbPT3aUo8G2lWLUhAQDwO0IjCrKsrUm1YeffRpH6OnV2DWj1wwdyDmDNMycXdS2jE/kEXQAAKgGhEQVpbWnUTYtnOw5TU6eM1+bdvaaBccK4kAJZzpr+zZETnoa22nBQy9qaPHt+AAC8xEYYFCz1pJate3rV8Uq/5c7ozOMBDZH6Ot138zx1dg0kd15nOnU6ptGYN1PTgYBUEw5oY3u3tnf0sZMaAFB1CI1w1YpFs7Vi0WxJ0l99b79GRp3V1TFGHltbGi1DoyQNn/HmYOhE4mxoldLLCgUDUtvcGcnXDABApSI0oii27ul1HBgNxlnTE8eHdXJotEgtc1dm0XFqOwIAKhWhEUWRy2kvBqMW4ryLG/X8q4c1GvNmVDEf+w/266Xe9zR0elRGs6ntCACoJGyEQVFkO+1lwaUzLDe0jIzGtf9gf1kFRsPJoQ8Do4HajgCASkFoRFEELXZBBwJnp3Hvu3leaRvkIWo7AgAqAdPTKIq2uTOSa/1SzZ87I/nvSH1dVQSq1FFV1jwCAMoVI40oihWLZmvBpTOSI47BwNlp6dRdxrkWBi9HqbUdO7sG0mpUGmsei32WNgAAbmCkEUWTWn7HjDHCljryVkkjjxPGhbT86llpr9PqPGtGGwEAfkdohKdSC4NL0jc2PK/jp8542CL3nMkoOWQViCspKAMAKhehETm5b9vLaae6NM+crNU3XlbwdTu7BrRt7+tlU5/RidRRxGxT0Jk7yVn3CADwI0IjHMsMjNLZYwFXfXefYnHlHXA6uwb02K6esiyzYyc6OJwMgVZSz7M21j0a09jUegQA+EVl70KAq6zOjTaOg853Y0elBkbDpp3dWaegU8NgtnWPAAB4iZFGZJU6VepErhs77tv2ckUHRkljCn6nypyaZt0jAMCvGGmEpcwSMU7lcn+r0ctqcUlTJO1jq5NyrG4HAKBUCI2wZDZV6gQBx7kDrw2kTeeb1a5MrfUIAIBXmJ6GpXymRAk4ucmczjerXZm6uYid1QAArxAaYSnXYtv5hJjmmZOrfoo6Ojis1Q8fSPZdZu1KAzurAQBeYnoalnI95u++m+flFF46uwb03rGhfJpWcZzsPGdnNQDAS4w0wpLZVOnwmZhpAe5c1zF2dg1o087urDuLq43dznOnO6uZwgYAFAOhEVllTpVmTpFKztcxbt3Tq45X+hUnKFrKthzAarlAamBnChsAUCxMTyMnrS2Numnx7GRQidTX6abFs20DydY9vdp/sPICY6S+TquWzkn2RzCgtP/nauJ467/jlrU1KRxKv3A4FEgL7ExhAwCKxbWRxrfeektr1qzR8ePHNXnyZK1fv14XXHCBW5eHj1ht1Mim45X+IrXGO6GA0qZ+U0f44omzI7A14YBOnY45vubJodG0TTEG42zuzELoiYwUTnFwAECxuBYav/nNb2r58uW67rrr9NOf/lR/93d/py1btrh1eZRAMdfCVdoIoySNHxdOW/dpNsJXW5P7j1h0cFgb27u1sb1bkfo6XdIU0YHXBkxrZsYSSlsH6WQKGwCAfLgyPR2NRtXd3a0lS5ZIkpYsWaLu7m69//77blweJZB5+ku+50hbyXe61s9SNwRZjeSZbRrKRXRwWPsP9mctsp763BQHBwAUiysjjYcPH9a0adMUCoUkSaFQSFOnTtXhw4d1zjnnOLpGJDLRjaaUtYaGSZ4999P/0Wk6Uvb0f7yla+d/vODrX/OHM7Wr8+2Cr+MnwWBA/3PdPp07ZbwmfaRGJz44M+Y+DVPGS5KOFrG0UMOU8cnvnWvnT1L9pHHasrtHvzs2pHOnjNcXFzdr/ifP13O/esf0dsfP4+H3Z6WhL91Ff7qL/nRPpfWlb3ZPR6MnFa/EOUyHGhom6ejRE549v1WoOXpsyFG77Ka2/7StSUOnz2j/wcpZ22h8v2YLhJ+4YIouPG+y6Y7zeRc36tW+aMHrDT/3mY+lfY1a/sdkrf9Ka9p9/s9zb6S14eixIW34t1c0eOK0oyUIXn9/VhL60l30p7voT/eUa18GgwHLgTxXQuP06dN15MgRxWIxhUIhxWIxvffee5o+fbobl0cJFLIWzmmZlxWLZlddyZ1X+6JasWi2JGnb3tdTpqsTeqn3PZ0cGtWEcSENn4mP2eTixIRxIbW2NNqG9my7qinFAwBwwpU1jZFIRM3Nzdq5c6ckaefOnWpubnY8NQ3vFbIWLpcyL+UUGEMuLMRMDeIjZz7so5HRRDJAnjodUyKesCy3UxsOqnnmZNPbl189y3Q96sb2bq1ct0+rHz6gzq4BdlUDAArmWp3Gb33rW3riiSe0aNEiPfHEE7rnnnvcujRKIN/6i1JuZV7KYRfvxPFhrVo6RzEXEq7xes2CdapYQqqrCWnTmoVpdR+Nr8PqGy8zvb21pTHrtY1RX6tAWg5fDwCAP7i2prGpqUk//vGP3bocPJBP/UXJ+dR2Z9eAhs84r1nYPHOyet4+nnN78lUbDuifb1uQ/NiY7s0UCEgJB3kydaTWyYiecR+rr4PV7XbXHhmNqyYcUG04mNdJPgAASJwIAxc4mdo2plBzKUHzmUtmKBgoXa2ekdH0JGj2uiSpJhRw1K7UkVonI3r5jvo5edyp0zHNu7gxr5FkAAAkH+2eRvlKLXCduhFDkm79wS/yrlW4be/rijsZ0isS43Wlb2A5Gy5DgbPT2HavbfXDBxQdHNbE8WGFAmenoc0UMup3SVPE0a70A68NEBQBAHkLJBIe/lZOQcmd8tyab6Wza0CP7erJa0ew1yaODyuRSOjU6ZiCAevNO8aondn08MTxYY2ciadNBwcDAcsQvODSGcld1lbMdkhLGlPOx87E8WHdeNVFOYXHSvv+9BJ96S760130p3vKtS+LXnIHyLS9o68sA6OUfopLtr9jooPDWrV0jmloMxuBzDZq+mpfNGubrMoa1dYEcwqMRtse3dmjp549pFOnY64fGQkAqEyERrgqdTSsUBPGhXTqtPONM6UWqa+znMLOlV1/bdv7umlZo1wDoyH+3yOpxnOb1dUEACAVoRE5yVZEOnM0rFAf+DgwSmfXEkpKlr0pJDRm28zS2TWQ87XNpsezGRmNa9ve17MWCAcAVDdCIxyzO/nFrhZhrgqZ3K6rCWrkTLyga9g58NqALjxvslpbGgsaWbXbBGNWJN0wYVxIZ0YTY0rp3HjVRZKkR3d2Oy6ofnJoNBlOU7+20tmzyY8eG1Kkvk6XNEWSxx8SLgGgehAa4ZjdUXR+Ol1k+Ix74dVK6mu3qlWZbSONwW5Hc7Z+XX71LEljd66nXm/Tzm7LXdvZjIzGtbG9W+FQILk+NTo4nLZTm6ltAKgehEY4Znfyi1VwqmTG613W1jRmar42HEwGQqP0TqbUdZFmOrsGLD9nnDstWQc243Zj00s+7DY0cYY1AFQHQiMcszv5xSw4VTrjtZvVqrykKaLtHX3a2N6tCeNCaSN2krPajNmmpo1zp83K8GTetuFv2pKPW7luX96v10q1/bEAANWI0AjHrEbTjKCSGZycTM2WO2MzjJR+zF/m+s9Tp2NpBcGdrgW0C2OZa0wf29WjRDyRnI4u1fQxZ1gDQOUjNMIxq5NfUsNI5vnI5Vzk25Dt5Ber+opm6z9jCamuJqQf/vUVjp872+iu2XOY9XPq9HFn10DWIuP54AxrAKgOhEbkJDMUmsmcMg2W7vjopHG1IZ0ecadkT7ZyN9HBYdMpYrv1n05lG93d2N7t+DrG827v6HMlMOY6YgoAKH+ERrgqc2TRq7VubgVGOxPGhUzLEFkVJs91Gjfb6G4uRdSzHXloaJ45WT1vH3d0vVxHTAEA5Y/QCFdt2/t6WU9F56I2HFQgENDIaHo4HBmNq7YmrNpw0HL9Zy6sRnfNRiHDoUDamsbM58023b36xst037aXHQVHNr4AQPUJet0AVJZCTkUpN7U1QcvXe3JoVDctnp0c4YvU19nWY8xVa0vjmOf40mebtXLJHMvnXdbWpNpw+o99aqhcfeNl2rRmoe1zs/EFAKoPI41AnrIFZKP+YrHX+lk9h13dRrvjArPV3Mw2YprtmEkAQHkjNMJVVmv5qonfdxM7CbNWNTcnjAtp+dWzTB9vd8wkAKC8ERrhquVXz8ppV2+lMGpSBgPSvIuLP8JYbJkjkg1Txutzn/lY1tf11LOHsh4zCQAob4RGuKq1pVFbfnZIw2eqa7TRKGIeT0j7D/Zr/8H+spyetZpebmiYpKNHT2R9nNUIM5tmAKAyEBrhunBIGj7jdSu859b0bKnWCWabXr52/qSsj8123GGkvk5b9/Sq45X+5Ghs29wZWrFotnuNBwAUHaERjmSWYmmeOVmrb7zM9L7VvqYxVaHTs6VcJ2h2wozR/mvnfzzrY7ONJkYHh7X/YH/y43IfjUX5YqMWUBhCI2yZ1e7refu47t7YqbWrWsfcP9vO22oUHRzWrT/4RXK3dbbNJJmyBTm3f9kVcopNvl/z6OCwNrZ3683fHmfkEUXFRi2gcNRphC2rYs/90SHd+oNfqLNrIO32S5oiJWhVeUktz3PqdEwb27u1ct0+3fL9jjH9l8qt4widsKq9GKmv03O/ekerHz6glev2afXDB8a02az+Yy72H+zP2g9AobL9AQbAGUIjCnJyaFSP7epJ/sLv7BrQgdf45e/UqdMxbdrZbRmYsgU5t1kV/r6kKaIHf/x/k0HVGKFJbXNmofF88MsbxVTKP8CASsX0NAo2GktoY3u3tnf06f+dGqmaYwTdEkso2X+Za6zM6iUWow6ksdZrZDSeLB9krPna3tE3Zje82RR5av3H1Q8fyPmXsTGNn0gkdOp0jDVncFW2IzQBOENohGv4i70wZmusnJ7gUojMtV7xxIfBtLWl0bLuZubXO3WTwYRxIYVDgZz/gEidxmfNGdxUqj/AgEpGaAR8ZGQ0rkd3ng1pqcGxmKHJbrONkxGazOB56nRMoYA0cXxYJ4dGk2FXkh7d2aN4wlmYpDg43FKKP8CASkdohK1NaxZq5bp9XjejasQT0qad3dq29/W0wFWsX252a72WtTWNKdieOUJjFjxjCamuJqQf/vUVY65tvLZc2ke5FBSqFOfBA5WMjTBwZNOahZoRGe91M8rWhHEhTRgXcnz/WOLDqVqjLM1X/3F/UXYYW63pCgbOBrXWlkb9r8//QfJ+kfo63bR4dtov31w2GbS2NOqHf32FNq1Z6Gg9WaS+Tp1dA9q0szttM062DUQAAPcRGuHY2lWtBMc8NM+crA1/01Zw0fPhM4m0nepusSqXE08ouUt6/ifP1303z9OmNQt1383zxozW5LvL265UjzGi+dSzh5S5PDKWkLb8rCfr9QEA7iE0IidrV7Vq05qFap452eumlI2et49r657enEYarYzGEtq293UXWvUho1xOMDD2c07r2FmV67HbZJBZqmfi+HCyn1JHNK0C9/CZBKONAFAirGlEXlbfeJm27ulNOx4O1vYf7FddTeGhUTo7bW2sMZ04Pqwbr7qo4HVaueyStnq8lN8mg8x1ZqlrF50EVjbKAEBpEBqRN+PYN4KjM5m1Dt1gFFeXCi9LU2gdOzc2GVgd9VZXE7LsP0o9AUBpEBpRkBWLZhMaPTYaS2QdbXO669gPdeysyv9MGBfS8BnzxxgbZZ569lByGtutEVgAwIcIjSjYjMh49UeHvG5GVYsODuvL6/cpnlDaiS6XNEV04LWBMSN30tiRST/UsbMaNTx1OqYFl84Y8weKcczhpp3daRtl3ByBBQCcRWhEwdauaqWOow/EE+n/jw4Om44CZyuY7WUdu2wbWiL1dbrwvMl6qfe9ZCmiCeNCWn71LG3v6Buzs1qyH4EFAOSG3dNwxaY1C+XSPo+yNmFcqCzOsvXjOsBsm14uaYpo8+7etILgZ0bPJsVsr8WPrxMAyhWhEa750eqFXjfBc8uvnqX7bp6nVUvnKBwyqWHjE34MttkC3qt9UcujDrO9Fj++TgAoV4RGuGrBpTO8boKnUs+L/tJnm9NOUfFTbctLmiJeN2GMbAXCs504s6ytSWb5PBwKlHQTDwBUOtY0wlVGGZ6OV/qTa+uqyTc2PK/7b7lckvn6wPu2vayet4970LJ0+w/2J79GfjnHOdvubWNzTqZIfV2y3U53T3OGNQDkJ5BIJHzxqz0aPal4NaaM/9bQMElHj57wuhmu6+wa0Jaf9Wj4TPV9bRdcOiMZolOdrUXYo5FR//WJVZtL9f1pFegy6zdKZwNl5hnYTq7vxnUKUak/616hP91Ff7qnXPsyGAwoEplo+jlGGlFUVrtxv7HheR0/ZVF4r0LsP9iv5w726yPjQjp1OpYWgow+8dupOkZbzIJjKVh9v7hVDsiqDiS7rAHAHqERnrj/lsu1dU9vxU9jJ6TklKlZjcQVi2ZrxaLZaSNsuTLqMb7aF3U0QmfnuYP9noXGbNwoB5RtbSQAIDtCIzyTGpge29WjUbNiexVmZDSup549ZFpY27ht9cMHHIeYSH2d7rt5nuXnjWtanSttJpHSBiOAXjt/kuPHO+HVukInRyWy5hEAzLF7Gp4z22m8aukcj1tVPKdOx7R1T6/l55e1Nak27OxH00m4bG1pzLn0jHFdY3T0uV+9k9PjszFGPzOfI1txb7eY9W3qUYletg0A/I6RRviC2dRja0ujvnb/cxoacT61Wi6yrR00W793emQ0Oc2dymkYXNbWlPdo7shoXFt292j9V1pzfqwZt9cV5jIymNm3wcCHz12MtgFAJSE0wtce+sZ83b2xsyLPtt5/sD8ZHjN3LWeGaKtdv07rEBrX2rb39bRTVZw6emxIt3y/Y8yGnny4ua4ws1+yna1tMG43e5zV2k/WPAIAoRFlYO2q9BEuv+04dsP+g/16/tXDGo0lTEOZG7uHjSCa7znh2Tb05MLJukKn8h0ZtHpcMCDTjVmcLAMAhEaUIWMDjVn42bTm7FGGuQSjiePDSiQSyVG0S5oieu6VfpW6gqkxdWwVytzYPSydPR/bbKo7FyOjcT26s1sb27tzDrDZinjnKt9RS6vPxxNn2+JG2wCg0hAaUbaMgJivYED6lzvMr/FS73t5TeO6pZjr6JZfPSun3dRWjBG56OCwNrZ3683fHndUqsetmotS/qOW2R6XegINu6cB4EOERlSttrnW52QXGhhXLZ2TdqxdPqKDw2NK37gRXlpbGl0JjZn2H+zXS73vWR7fl9kGN15LvqOW2R7nVtsAoNIQGlGR2v/xOi393z81/VwwcDYwZhsVsxqJciKgsaEo3808maVfpPzWEWbKNkU9cXw479B8cmg0p1HHQuU7aunmaCcAVAvOnvaJcj2j0q8K7U+rguOhgLRyyRy9+dvjlptxrM5vdmMDz4RxIW34m7aCriGdfX2bdnYr9eUZr62QzTKZrPqiXBSj0Dc/6+6iP91Ff7qnXPsy29nTFPcGTLS2NKquZuyPRyxxdnRqxaLZWnDp2OntbCFpxaLZBRctP3U6plt/8IuCi023tjRq5ZI5aQXVjcBofOyG/Qf79dV/7CjL4tgU+gaAdIw0+kS5/kXiV270Z7bRtkI34bgx6jhxfNjR+sF8ZDuzeuL4sM6fOlE9bx93fL3acFA3LZ5dVtO/Vsc5ThwfVl1NKO/RR37W3UV/uov+dE+59mW2kUbWNAIW3KwnmCn13G1j+jNXJ4dGXV3nmCpzzV/DlPH63Gc+NqbguNPNPiOjcW1s705uwJkwLqTlV8/yPERmm362+pqcHBpNrvl0e60pAPgZoRGw4GY9QSupG2ZSA4xVkelMxSzNk9o2s7+Yjc/nM2p66nRMm3Z2J6/jBbvTZJxuhuKYQQDVgtAIWCj1DtvMAOm0LI7XR9ytWDRbF543WVt+dkjDZ5yXGDLWh5Y6bGUb3U0NgGZ/NFjx+msAAKVAaASy8KpmX2tLY9Yd2qn8cMRdvqOO0cFhrVy3LzmyWuxgnm2tZmqbJPM/Gk6PjJpOx/vhawAAxUZoBHzKGMHLtubRb0fcGW3OtXh4vqfL5MrszOlMqQEw848Gs9Dpt68BABQLoRHwMbPQ4ueC1EaoKtT+g/164deH9cVrml19fXbTyHYBkKLgAKoZoREoI7lOl5c6ZDoZyXNq+ExCj+3qkeTeZplsm1tyOU2GkAigGhEagQpltzu4GNzeEDIaS2hje7e27X3dlZqUVjviy62GJAB4gRNhgAplNupn7A4uFqsNIRPHh9NOn6kNB3K67smhUT22q8eVk3BuWjw7rS0ERgBwhpFGoEJZjfoVszyM1Uhe5ihhPmdbj8YSrpToqYTpZb+vbQVQmQoeafzpT3+qpUuXas6cOXriiSfcaBMAF1iN+hWzPIzTkbyJ4/P7e5V6iJyJDcA7BY80Njc364EHHtAjjzziRnsAuKQUJ9qYsRvJ6+wa0NDp0byuTT3E7MsOGG0EUEwFh8aLLrpIkhQMsjwS8BO/lofZ3tGnmIMjEjOFQwHqIcqbZQcAIPloTWMkMtHrJniuoWGS102oKPSndO38Sbp2/sdduZZb/fl+HuFmXG1IX/vTP9D8T57vShu8VkhfNkwZr6PHhkxvr9bv+Wp93cVCf7qn0vrSNjRef/316u83PxbshRdeUCgUcqUh0ehJxeN5DD9UiIaGSTp69ITXzagY9Ke73OzPc7LUSsw0YVxIy6+elRwdzWxDOW4IKbQvP/eZj5kuO/jcZz5Wld/z/Ky7i/50T7n2ZTAYsBzIsw2NO3bscL1BAKqX1VrLeRc36tW+6JgA2Nk1oNUPHzC9PbMO5aM7e5JHGAYDUtvcGUU5jtBLfl12AKDy+WZ6GkB1yCX0ZCtQbrYhJJ5IpPz77HGEkioyOBISAZRawaFx586d+u53v6vBwUH9/Oc/1yOPPKJNmzbpwgsvdKN9ACqQ09CTbaew0ynujlf6Ky40AoAXCg6NS5Ys0ZIlS9xoCwCkybZTONs50qmqeKk0ALiKOjkAfCtbgfJlbU2qDdu/hQVzO7EQAGCB0AjAt8yCoVGgPPP0mboa80oObXNnFL2dAFAN2AgDwLfsNs1kro3cuqdXHa/0K56o3N3TAOAVQiMAX8tlp/CKRbNzConlWOcRALxCaARQlbKV8yE4AsBYhEYAVSlbOZ9yD42MoAIoBkIjgKqUrZxPOWMEFUCxsHsaQFXKVs6nnGUbQQWAQhAaAVSlbOV8ylmljqAC8B7T0wCqVk04oJHRs/+eOD6sG6+6yHdTuLmuT7Q6KafcR1ABeI+RRgBVx1j3d+p0LHnbyJl4lkd4w2inEQKN9YmdXQOWj6nUEVQA3iM0Aqg65bLuL592Zp6UE6mv002LZ/tuBBVA+WF6GkDVKZd1f9naufrhA5ZT1rkURAcApwiNAKqO3bo/v9Q5tGqnpDFT1hIldQAUF9PTAKpOtnV/+awjLGU7zfhxah1A5SE0Aqg62db9+Wm9o1k7rfhtah1A5WF6GkBVslr357f1jpntNNYyZqKkDoBiY6QRAFL4/aQYSuoA8AqhEQBS+D2UUVIHgFeYngaAFEb48sPuaSuU1AHgBUIjAGSo5lDml3JDAPyH0AgAkPThsYXG7nFqQAJIxZpGAICk8jleEYA3CI0AAEn+KzcEwF8IjQAASf4vNwTAW6xpBIAK4MYGlmVtTWlrGiV/lRsC4C1CIwCUObc2sJRDuSEA3iE0AkCZy7aBxWngyxypXLV0DmERQBpCIwCUuUI3sFBqB4ATbIQBgDJX6AYWSu0AcILQCABlrtDzsim1A8AJpqcBwAcK2f1c6AaWSH2daUCk1A6AVIRGAPCYG2sKCzkvm1I7AJxgehoAPOb1msLWlkbdtHh2cmQxUl+nmxbPZhMMgDSMNAKAx/ywprCQkUoA1YHQCAAeK8WaQjdOjAFQ3ZieBgCPFbr72Y6xZtIIpsaayc6uAVeuD6A6EBoBwGPFXlPo9ZpJAJWB6WkA8IFirin0w5pJAOWPkUYAqHCFnhgDABKhEQAqXrHXTAKoDkxPA0CFK/TEGACQCI0AUBWowwigUExPAwAAwBahEQAAALYIjQAAALDFmkYAQMlwnCFQvgiNAICSMI4zNE6nMY4zlERwBMoA09MAgJKwOs5w297XPWoRgFwQGgEAJWF1bOHJoVF1dg2UuDUAckVoBACURLZjC7d39JWwJQDyQWgEAJREtmMLrUYhAfgHoREAUBKtLY2aMC5k+rlso5AA/IHQCAAomeVXz1JtOP1XT204mHUUEoA/UHIHAJCXfGouGp+nViNQfgiNAICcFVJzsbWlkZAIlCFCIwAgZ1Y1F7d39FkGwmKdBsMpM9WDr7W3CI0AgJxZ7XY2u72za0BPPXtIp07H0u7nxmkwz/3qHU6ZqRKcKOQ9NsIAAHJmtds583bjF31qYDQYI5OF2LK7x3LEE5Ul2+g2SoPQCADI2bK2Jke7oM1+0acqtD7j744NFeW68J9cRrdRHIRGAEDOWlsaddPi2cmRxUh9nW5aPHvMNKHdL/RC6zOeO2V8Ua4L/3E6uo3iYU0jACAvTnZBR+rrLIOjG/UZv7i4WRv+7ZW00cxwKKDTI6NauW4fmyUqyLK2prQ1jRI1PkuNkUYAQNGYTWNL0sTxYdORyVzN/+T5aSOeE8eHlYgnkmsojc0SnV0DBT0PvOd0dBvFw0gjAKBoSlHMO3XEc/XDB3RyaDTt83algFA+qPHpLUIjAKCoSvmLns0SQPEwPQ0AqBhslgCKp+DQeM899+iaa67RtddeqxtuuEGvvfaaG+0CACBnTksBAchdwdPTV1xxhf72b/9WNTU12r9/v77+9a9r7969brQNAICclGINJVCtCg6NCxYsSP577ty5GhgYUDweVzDIzDcAoPTYLAEURyCRSCTcutiDDz6o3t5ePfjgg25dEgAAAD5gO9J4/fXXq7+/3/RzL7zwgkKhkCTpmWeeUXt7u5588sm8GhKNnlQ87lp+LTsNDZN09OgJr5tRMehPd9Gf7qEv3UV/uov+dE+59mUwGFAkMtH0c7ahcceOHbZP8Oyzz+qBBx7Q448/rnPPPTf3FgIAAMDXCl7TuH//fn3nO9/RY489pvPOO8+NNgEAAMBnCg6Nd955p2pqanTrrbcmb3v88cc1ZcqUQi8NAAAAnyg4NP7yl790ox0AAADwMeriAAAAwBahEQAAALYIjQAAALBFaAQAAIAtQiMAAABsERoBAABgi9AIAAAAW4RGAAAA2CI0AgAAwBahEQAAALYIjQAAALBFaAQAAIAtQiMAAABsERoBAABgi9AIAAAAW4RGAAAA2CI0AgAAwFbY6wYAAICzOrsGtL2jT9HBYUXq67SsrUmtLY1eNwuQRGgEAMAXOrsGtHl3r0ZG45Kk6OCwNu/ulSSCI3yB6WkAAHxge0dfMjAaRkbj2t7R51GLgHSERgAAfCA6OJzT7UCpERoBAPCBSH1dTrcDpUZoBADAB5a1Nak2nP5ruTYc1LK2Jo9aBKRjIwwAAD5gbHZh9zT8itAIAIBPtLY0EhLhW0xPAwAAwBahEQAAALYIjQAAALBFaAQAAIAtQiMAAABsERoBAABgi9AIAAAAW4RGAAAA2KK4NwAAZewbG57X8VNnkh9PnlCj+2+53MMWoVIx0ggAQJnKDIySdPzUGX1jw/MetQiVjNAIAECZygyMdrcDhSA0AgAAwBahEQAAALYIjQAAlKnJE2pyuh0oBKERAIAydf8tl48JiOyeRrFQcgcAgDJGQESpMNIIAAAAW4RGAAAA2CI0AgAAwBahEQAAALYIjQAAALBFaAQAAIAtQiMAAABsERoBAABgi9AIAAAAW4RGAAAA2CI0AgAAwBahEQAAALYIjQAAALBFaAQAAIAtQiMAAABsERoBAABgi9AIAAAAW2GvGwAAAPyns2tA2zv6FB0cVqS+TsvamtTa0uh1s+AhQiMAAEjT2TWgzbt7NTIalyRFB4e1eXevJBEcqxjT0wAAIM32jr5kYDSMjMa1vaPPoxbBDwiNAAAgTXRwOKfbUR0IjQAAIE2kvi6n21EdCI0AACDNsrYm1YbTI0JtOKhlbU0etQh+wEYYAACQxtjswu5ppCI0AgCAMVpbGgmJSFNwaPynf/on7dq1S6FQSIlEQl/5ylf02c9+1o22AQAAwCcKDo1f+MIX9NWvflWSdOTIES1evFjz5s3T7/3e7xXcOAAAAPhDwRthJk2alPz3Bx98oEAgoHg8nuURAAAAKDeBRCKRKPQi27Zt0+bNmzUwMKBvf/vbTE8DAABUGNvQeP3116u/v9/0cy+88IJCoVDy40OHDum2227Tli1bNGXKlJwaEo2eVDxecH4tWw0Nk3T06Amvm1Ex6E930Z/uoS/dRX+6i/50T7n2ZTAYUCQy0fRztmsad+zY4fiJZs2apalTp+rFF1/UokWLnLcQAAAAvlbwmsY333wz+e933nlHPT09uvDCCwu9LAAAAHyk4N3TGzZs0JtvvqlwOKxQKKS7775bTU1UjAcAAKgkBYfGH/zgB260AwAAAD7G2dMAAACwRWgEAACALUIjAAAAbBEaAQAAYKvgjTAAAABwrrNrQNs7+hQdHFakvk7L2prU2tLodbNsERoBAABKpLNrQJt392pkNC5Jig4Oa/PuXknyfXBkehoAAKBEtnf0JQOjYWQ0ru0dfR61yDlCIwAAQIlEB4dzut1PCI0AAAAlEqmvy+l2PyE0AgAAlMiytibVhtPjV204qGVt/j+CmY0wAAAAJWJsdnGye9pvu6wJjQAAACXU2tJoG/78uMua6WkAAACf8eMua0IjAACAz/hxlzWhEQAAwGf8uMua0AgAAOAzftxlzUYYAAAAn8lll3WpEBoBAAB8yMku61JiehoAAAC2CI0AAACwRWgEAACALUIjAAAAbBEaAQAAYIvQCAAAAFuERgAAANgiNAIAAMAWoREAAAC2CI0AAACwRWgEAACALUIjAAAAbBEaAQAAYCvsdQMMwWDA6yZ4jj5wF/3pLvrTPfSlu+hPd9Gf7inHvszW5kAikUiUsC0AAAAoQ0xPAwAAwBahEQAAALYIjQAAALBFaAQAAIAtQiMAAABsERoBAABgi9AIAAAAW4RGAAAA2CI0AgAAwBahEQAAALZ8c/Z0tbnnnnvU2dmp2tpafeQjH9Fdd92liy++eMz9tm/frm9/+9v66Ec/Kkk677zz9NBDD5W6ub701ltvac2aNTp+/LgmT56s9evX64ILLki7TywW09q1a/X8888rEAjoL//yL/X5z3/emwb72LFjx3T77bfrN7/5jWprazVz5kzde++9Ouecc9Lut2bNGr3wwguaMmWKJOmaa67RV7/6VS+a7GsLFy5UbW2t6urqJEm33XabLr/88rT7DA0N6c4771RXV5dCoZDuuOMOLViwwIvm+tpvf/tbfe1rX0t+fOLECZ08eVIvvvhi2v02bNigp556SlOnTpUkXXbZZfrmN79Z0rb61fr167Vnzx69++67am9v10UXXSTJ2XuoxPtoKrO+dPr+KVXAe2gCnti3b19iZGQk+e8rr7zS9H4/+clPErfcckspm1Y2VqxYkXj66acTiUQi8fTTTydWrFgx5j47duxIrFy5MhGLxRLRaDRx+eWXJ955551SN9X3jh07lvjlL3+Z/HjdunWJO++8c8z97rjjjsTWrVtL2bSytGDBgsShQ4ey3mfDhg2Ju+66K5FIJBJvvfVW4o/+6I8SJ0+eLEXzytratWsT99xzz5jbf/jDHybWrVvnQYv876WXXkr09/eP+b508h6aSPA+msqsL52+fyYS5f8eyvS0RxYsWKCamhpJ0ty5czUwMKB4PO5xq8pHNBpVd3e3lixZIklasmSJuru79f7776fdb9euXfr85z+vYDCoc845R1dddZV+9rOfedFkX5s8ebI+/elPJz+eO3eu+vv7PWxR5du9e7f+7M/+TJJ0wQUX6BOf+IR+8YtfeNwqfxsZGVF7e7v+5E/+xOumlJVPfepTmj59etptTt9DJd5HU5n1ZTW9fxIafeDJJ5/U/PnzFQyafzlefPFFXXfddfrzP/9zPffcc6VtnE8dPnxY06ZNUygUkiSFQiFNnTpVhw8fHnO/GTNmJD+ePn26BgYGStrWchOPx7Vt2zYtXLjQ9POPPfaYli5dqptvvll9fX0lbl35uO2227R06VJ961vf0uDg4JjP9/f3J5edSHxvOrFv3z5NmzZNLS0tpp9/5plntHTpUq1cuVIHDx4scevKi9P3UOO+vI86Y/f+KZX3eyhrGovk+uuvt/xL44UXXkj+oD7zzDNqb2/Xk08+aXrf+fPn67Of/azGjRun7u5urVq1Slu2bFFTU1PR2o7q9vd///f6yEc+oi984QtjPvf1r39dDQ0NCgaDevrpp/XlL39Ze/fuTX4/46wnn3xS06dP18jIiP7hH/5B9957r773ve953ayy95Of/MRylPGGG27QX/3VX6mmpkYHDhzQzTffrF27diXXjgGlkO39Uyr/91BGGotkx44d+s///E/T/4xvjmeffVYPPPCAHn30UZ177rmm1znnnHM0btw4SdKcOXN02WWX6dVXXy3Z6/Cr6dOn68iRI4rFYpLOLtR+7733xkwbTJ8+PS28Hz58WI2NjSVtazlZv3693n77bX3/+983HfmeNm1a8vbPfe5z+uCDDxhxMGF8H9bW1mr58uV6+eWXx9xnxowZevfdd5Mf872Z3ZEjR/TSSy9p6dKlpp9vaGhILvmZN2+epk+frjfeeKOUTSwrTt9DjfvyPmrP7v1TKv/3UEKjR/bv36/vfOc7evTRR3XeeedZ3u/IkSPJf7/77rt65ZVXNGvWrFI00dcikYiam5u1c+dOSdLOnTvV3Nw8ZrfaNddcox//+MeKx+N6//33tXfvXi1atMiLJvve/fffr1//+td66KGHVFtba3qf1O/H559/XsFgUNOmTStVE8vCBx98oBMnTkiSEomEdu3apebm5jH3u+aaa/Sv//qvkqT/+q//0muvvTZmhzU+tGPHDrW1tVmOHKZ+b/b09Ojdd9/Vxz72sVI1r+w4fQ+VeB91wsn7p1T+76GBRCKR8LoR1egP//APVVNTk/YD+vjjj2vKlCm66667tHDhQl155ZW6//779fOf/zw5OvmlL31J119/vVfN9pW+vj6tWbNGg4ODqq+v1/r16/X7v//7WrVqlW699VZdfPHFisViuvfee3XgwAFJ0qpVq5KbD/ChN954Q0uWLNEFF1yQHNk2yjtdd911euSRRzRt2jT9xV/8haLRqAKBgCZOnKjbb79dc+fO9bbxPvPOO+/olltuUSwWUzweV1NTk+6++25NnTo1rS8/+OADrVmzRj09PQoGg1q9erWuuuoqr5vvW4sWLdJdd92lK664Inlb6s/6HXfcoa6uLgWDQdXU1OjWW29VW1ubhy32j7Vr1+rf//3f9bvf/U5TpkzR5MmT9cwzz1i+h0rifdSCWV9+//vft3z/lFRR76GERgAAANhiehoAAAC2CI0AAACwRWgEAACALUIjAAAAbBEaAQAAYIvQCAAAAFuERgAAANj6/7BJazC5d9NlAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 792x576 with 1 Axes>"
       ]
@@ -1778,7 +1773,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [
     {
@@ -1787,7 +1782,7 @@
        "array([0, 0, 0, ..., 0, 0, 0])"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1800,12 +1795,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAo0AAAHUCAYAAABfxBLvAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/d3fzzAAAACXBIWXMAAAsTAAALEwEAmpwYAABps0lEQVR4nO3dd3QUVRsG8Gdme3ohhFBD772DdBFQEBEVLIgoIFhQFBUFRRAVREEBRVAEqfrRpQhI7x2k905CSEJC2taZ+f6IROJusimb7G7y/M7xHDMzO/PuZbM83Jl7r6AoigIiIiIiomyI7i6AiIiIiDwfQyMREREROcXQSEREREROMTQSERERkVMMjURERETkFEMjERERETmldncB9yUkpEKWi+/sP6GhfoiPT3F3GUUG29O12J6uw7Z0Lbana7E9Xcdb21IUBQQH+zrc5zGhUZaVYh0aART79+9qbE/XYnu6DtvStdiersX2dJ2i1pa8PU1ERERETjE0EhEREZFTDI1ERERE5BRDIxERERE5xdBIRERERE4xNBIRERGRUwyNREREROQUQyMREREROcXQSEREREROMTQSERERkVMMjURERETkFEMjERERETnF0EhERERETqndXQBRUWFNNiLh2CWo/fQIrlcJgor/JiMioqKDoZHIBa4t2YGzXy+FqFFBUQC1jw5NZ7wJ/ypl3F0aERGRS7ArhCif7p26hrPfLIVstsKWYoKUaoI59h4ODJkKRZLdXR4REZFLuKSnMSEhAe+//z6uX78OrVaLChUqYNy4cQgJCXHF6Yk82vWlOyBbbHbbJaMFdw+fR2izGm6oioiIyLVc0tMoCAIGDhyIDRs2YPXq1ShXrhy+/vprV5yayONZElMBWbHbLgCwppgKvyAiIqIC4JLQGBQUhObNm2f83KBBA0RFRbni1EQer1THBlAZtHbbZasNIQ2ruKEiIiIi13P5M42yLGPx4sXo2LGjq09N5JEiujaBX5XSUOn/CY4CoNJrUfW1HtAG+7m3OCIiIhcRFEWxv6+WD2PHjkVMTAymT58OUeQ4GyoeJLMVV1buwdU/9kMX5ItqL3ZCeHM+y0hEREWHS0PjxIkTce7cOfz444/Qau1v12UnPj4FsoPnwoqLsDB/xMYmu7uMIoPt6VpsT9dhW7oW29O12J6u461tKYoCQkMd3yVz2TyNkydPxsmTJzFr1qxcB0YiIiIi8mwuCY0XLlzAzJkzERkZib59+wIAypYti++//94VpyciIiIiN3NJaKxatSrOnTvnilMRERERkQfiSBWifEq9cwdbHx2NHU9/5u5SiIiICgzXnibKh/XN3oBikTJ+/rPBUPhUDEe7FZ+6rygiIqICwJ5Gojza++qUTIHxvrQrMbhz4oobKiIiIio4DI1EeZS4/3yW+w73n1SIlRARERU8hkaiglCM5xwlIqKiiaGRqADoS4e6uwQiIiKXYmgkyqPGP7+d5b4O68YXXiFERESFgKGRKI9KNqmOmqP72m1vu3GsG6ohIiIqWJxyhygfIp9qh8in2rm7DCIiogLHnkYiIiIicoqhkYiIiIicYmgkIiIiIqcYGomIiIjIKYZGIiIiInKKoZGIiIiInGJoJCIiIiKnGBqJiIiIyCmGRiIiIiJyiqGRiIiIiJxiaCQiIiIipxgaiYiIiMgphkYiIiIicoqhkYiIiIicYmgkIiIiIqcYGomIiIjIKbW7CyDyJjdW7cHJMfMzbas0uBuqv/a4myoiIiIqHOxpJMohc1KSXWAEgMuz/kTckQtuqIiIiKjwMDQS5dCu3l9kue/Q0GmFWAkREVHhY2gkyiHL3aQs9ylmayFWQkREVPgYGolySBPgm+U+QcvHg4mIqGhjaCTKoTb/+zjLfY2+HVKIlRARERU+hkaiHNKFBaDqW0/YbS/9eEuUbFW78AsiIiIqRLynRpQLVQZ0QZUBXWBOSgLM6UGSiIioOGBoJMoDXQDDIhERFS+8PU1ERERETjE0EhEREZFTDI1ERERE5BRDIxERERE5xdBIRERERE4xNBIRERGRU5xyhygHzHH3cGfHCUAQULJdXehCOOUOEREVLwyNRE5cX7YLZyb+DkEUAQE4PeF31Bn9HMr0aOHu0oiIiAoNb08TZSPtVhzOfPU/yBYbJJMFktEC2WzFyfGLYIpJdHd5REREhYahkSgbt/86AkWSHe/bcrSQqyEiInIfhkaibCg2CYqi2G+XZShWyQ0VERERuQdDI1E2SravB1GtstsuiCJKtqvnhoqIiIjcg6GRKBv+Vcog8vmOEPUaQBAAUYCo16DSgC7wrVDS3eUREREVGo6eJnKi+rAnUKpzI0RvOAxBFBDxSGME1Cjn7rKIiIgKFUMjUQ4E1iyPwJrl3V0GERGR2/D2NBERERE5Vax6Gi9evIxt23fBz88X3bp2RmAgV/UgIiIiyoliERoVRcHYcV/h13mLoCiASqXCR6PGY84v09GubWt3l0dERETk8YrF7endu/dj/oLfYDKZYTabkZaWBqPRiIGDhsFoNLm7PCIiIiKPVyxC4+9LViAtzWi3XYCA3bv3uaEiIiIiIu9SLEKjZLM53K4AsElc1YOIiIjImWIRGns90R0+Pga77ZJkw0Otm7uhIiIiIiLvUixC48MPt0fXLp3g42OAIAjQaDTQ6/WYMvkL+Pn5ubs8IiIiIo9XLEZPC4KA6dMm4eCho/jrr63w9/dDr17dUa5sGXeXRkREROQVikVoBNKDY7OmjdCsaSN3l0JERETkdYrF7WkiIiIiyh+GRiIiIiJyiqGRiIiIiJxiaCQiIiIipxgaiYiIiMgphkYiIiIicoqhkYiIiIiccllonDhxIjp27Ijq1avj/PnzrjotEREREXkAl4XGTp06YeHChShThqusEBERERU1LlsRpkmTJq46FRERERF5GD7TSEREREROecza06Ghfu4uwe3CwvzdXUKRwvZ0Lban67AtXYvt6VpsT9cpam3pMaExPj4Fsqy4uwy3CQvzR2xssrvLKDLYnq7F9nQdtqVrsT1di+3pOt7alqIoZNmRx9vTREREROSUy0Lj+PHj0bZtW9y+fRsDBgzAY4895qpTExEREZGbuez29OjRozF69GhXnY6IiIiIPAhvTxMRERGRUwyNREREROQUQyMREREROcXQSEREREROMTQSERERkVMMjURERETkFEMjERERETnF0EhERERETjE0EhEREZFTDI3FhMViwdGjx3H+wiUoiuLucoiIiMjLuGwZQfJcq1evx7vvjYaiKJAkGeXKlca8uT+iQoVy7i6NiIiIvAR7Gou4s2fP463hI5GcnIKUlFQYjUZcvHgFTz3TH7Isu7s8IiIi8hIMjUXcr/N+g8ViybRNlmUkJNzDgYNH3FQVEREReRveni7ibt+OgSTZ9ygKAhAXF++GijxTzLVofPPmBMTdugMACI0ogeHTRqJ0xTJuroyIiMgzsKexiOvUsS0MBoPddqvViqZNGrqhIs9jMVkw+pn3MgIjAMRHx+GTPu/DZDS5sTIiIiLPwdBYxPXu3RPlypWGXq/L2ObjY8CggS8iPLykGyvzHKt/Xg7JJtltlyUZq2YsdUNFREREnoe3p4s4g0GPdWv+hzlzF2H1mvUICAjAywOeR9cundxdmse4cvpy1vvOZL2PiIioOGFoLAZ8fX3xxuuD8Mbrg9xyfUVRsOuPbVj362okJyShav3qeGrYsyhTqaxb6vmvctXK4/T+E473VS1fyNUQERF5Jt6epgK3auZSLPzqV8Rci0ZaUir+3nUEn/f/GDE3bru7NABAz1efgqiy/1UQRAG9XnvGDRURERF5HoZGyuTOzRj879uF+P79KdiyZCNMafkbCGJKM+HPeWtgMZn/3agAZpMFq39ajlP7juPo9kNIS07LZ+V5pzfo8cm8zxEYGpSxLSAkAB//Oh4+fj5uq4uIiMiT8PY0ZThz8BS+e3sSJJsNkk3Cid3H8OevqzFmwRfwC/LP0zljrkdDpVbBas68XZFl7P1zF45sOwQAkGwSXvjgJbTp2SG/byNPyteIxJSNM2Cz2QAAajV/NYiIiB7EnkYCkP7c4c+f/ACLyZwxkthisuBeXCLWzlmZ5/MGh4fCZrU5vqaswJRqhCnVCKvZgoUT5+LWpRt5vpYrqNVqBkYiIiIHGBoJABAXFYvUpBS77TarDYc2H8zzeQOCA9CofRNodFqnx9psNuxctc3hvrTkVOxctRV/LfoT0Vej8lwPERER5Q27VAgAoNVrITtYOQYA9D46h9tz6pVPh2DhpF+xd+1OKIoCrUEHi8kCm8Wa6ThZkpGWnGr3+lP7juO74ZMgSzIURYHw3QI83Kcr+gx/AYIg5Ks2IiIiyhmGRgIABIYGIbJWJVw+eTFTeNTqdejUp0uWr9u9ZgeWTF2ElMRk+AcHoM/wF9Cia+tMx2h0Wrw0ehCef68/TGkmWC1WfPjEcLtz6Qw6NGzfJOPnq6cvY9vyzdixcgug/HucIivYuHAdNi5cl7Htl8OL8/K2iYiIKId4e5oyDJ34FkqWDYfORw+9jx4arQZNHm6Otr06Ojx+w4K1mD1mBpLi70GWZNyLS8SsUdOxdclfDo/X6LTwDw5ASHgoHhvQE1q9Dvino1Bn0KFqg+qo/1AjSDYJEweNw7h+o7BjRebAmJWXGz8LSbJf1YWIiIhcgz2NlCE4LASfL/sGF46dQ2JsAiJrVkLJcuFZHr9s+m8Ot//+7QJ0eLpzlq9TFAU1mtZGcmIybl68Dh8/HzTv2hpNOjWHqBKxds4qnDtyJtf1D2r2AkqUCcP4pV/n+rVERESUPYZGykQQBFRrWMPpcbIsZzkq2mKyZPk6q9mCb17/EtfOXoFkk6DWqGHwM+DZ9/pnTLC96bf1eSseQNytWAxp2R8AoNPrYP5nfkidQY93f/gQVepVy/O5iYiIijOGRsoTUcz6yYbsBqesnbMKV05fgtWcPgjGZrXBbDJj1qjp+OiXsenbLI7DaG6ZH5hQ3Gw04YsBYxweF1qqBB7q2R6P9u+Ro1HeRERExRGfaaQ8q964lsPtdVrWy/I1u/7YnhEY71NkBVdOX86Y8qfxw81cV2QOxN+Ow6qZS/HFK59CUXLwACUREVExxNBIefbu9A9Rtmr5TNsia1bEm1NGZPmarAarSFYb3nr4Vfw+ZQF6v9YnzyvQ5Me1M1ew4sclhX5dIiIib8Db05Rnaq0a436biLsx8bh65jIq1q6M4LCQbF/T7JGW2LrkL4fPQ8qSjA0L1iI1KRWT1kzFhgXrcGDjHqjUKkRdvpWxUk1BWvvLSvQc1BsqtarAr0VERORN2NNI+RYSHopG7Zs6DYwA0HPwUwj7Z1qfrOz6Yxt0Bj0eH/Qkxi/5GmMXT8SQCcOg1Wuh9zVAZ8jfZOPZuX+rnIiIiDJjaKRC5ePvg7GLJ+DlT17N9rh3ur6GZdN/gzHVCABo3KEZpmyYgZdGD8JLHw8u0BoV2fHKOERERMUZQyMVOrVGjaadW2R7TGJsAjYsXIcJA8dm3JY2+Pmg2SMt0bxLK/Qc+lSB1ecfElBg5yYiIvJWDI3kFmajCYKY/brRNosVNy9cx6in3sWOlVszPQcZUT6iwGq7cPRsgZ2biIjIW3EgDOXLvbhErJ+/Gqf3n0RwqVB0e7EHqjeq6fR1+zfshSI7n95GURTcuRGDuZ/NwpYlGzF67mc4f+QMfvxwmivKJyIiohxiaKQ8S4i9izF9R8KYaoRkteHGhes4vf8EOvXpgnJVK+DUvuM4vusYtHot2vfuhG79H4dak/6RO38098sEXj93FYc27cfv3y5w9VvJxGyyQpZk7F6zHTtWbIUkSWjdvS3aPdkpo34iIqLihn8DUp6tnb0SxpS0TFPh2Cw2bJi/NtNxqUnA2l9W4drZq3jj63cAAKZkY+4vqAC71+7AvbjE/JTt1KKv5mDXqi24fe02LP+sKhN1+SYObd6P934cne1qOEREREUV//ajPDu573iO5060mC04sedvRF+5BQCw2vK2VKBGqwGyfxTSJa6fu5YRGIH09bSvnrmC0/tOFPzFiYiIPBBDI+VZYGhQro5XqVW4ceE6AMDga8jTNRPu3AXctNKfOc2Es4dPu+fiREREbsbQSHnW9cXu0OpzPtG2IssoUToMNqsNdVs3gEanzdX1WnVvg1uXbua2TJfR6DS5DspERERFBUMj5VnDdk3Q89Xe0Oq0UGudPx7r4++LMwdPYVinQZj/5S+QbDYIogiVWpWjZftKVyzjtl5GABBFEc27tXZfAURERG4kKIrixr+G/xUfnwI5B1OwFFVhYf6IjU12dxl5Ykoz4caF6/jurYlIS07L8jhRJUJRlExT7Wi0GlSpXw3Nu7ZG5bpVMPaFUbBZrA5fL4hCjqbpcTVBEKD3NaBR+yao3aIeGndqlv5sZTHizZ9PT8O2dC22p2uxPV3HW9tSFAWEhvo53lfItVARpPfRo2r9avj6z+/RuGN6oHI0cbcsyXahz2qx4vLJi3ioRzuUqVwOYWXCsryOOwIjkD5XpGSzYfeaHfj1i5/xfo9h2L5iC25duuGWeoiIiNyBU+6Qy+gNerw+aTgAYGibATCnmXL0OovZgq+++hZdu3VG5TpVEH0lqiDLzBOLyQIgfTCMOc2EX8f/BAAICA3Ep4smIKhEEID0gBkfHQcACI0oAUEohKHeREREhYChkVzuwF97cxwYAcBotWDaDz9j1ux56PpwR4gqEbIkF2CFrpMUfw/vdBkK3wBf1GpWF9fOXUHCnQQA6aFx6IRhKFe1gpurJCIiyj/eniaXO7b9SPYHPND5JskyTifdgCzLMBpN2LB5K6p2qFewBRaA1KRUHNy0D3duxMBqtsBqtuD21ShMHDQOplwEaCIiIk/F0EguV7JsySz3lalSFnVbNYDOz4B7UhoOJ15GjPlexv5yYjDO/nW0MMosFJJNxqFN+91dBhERUb4xNJLLPfpST4cDYQBg8GdvYPjUD/DYe8/guPEm4i3/jizzFXWo6FuySD0HaDGZkRB7N9M2WZbhIZMWEBER5RhDI7mcVq/F+z9+DK3+38m7RZWIF0cNRLlq6c/3tW//EKT/PLdYyS+8UOssDFq9DpXrVgUAnDt8Gp/0eR8Dmz6P19u9guU//C/HyzASERG5GwfCUIGo3rgmftz9K66evQxzqhlVG1aHKP77bxQ/Pz/8+MM3eHXoOxAEAZIkQS0WrX/DaHRaVKgRiZpNa+Pa2SuYMmxixihsU6oRGxeuRXJCEvqPGujmSomIiJxjaKQCFVmjUpb7HnmkIw4e2IJ16zYiLc0IVbwFe5dtK7ziCpIA1G/TEIM+ex2CIGDN7JUZgfE+i8mC3Wt24Kk3+8I3wPFEqkRERJ6CoZFybM0vK7Fixv8yJtkOLhmCcf+bCF//vAeeEqEheLFfX1gtVuzfsKfohEYFOL3vRMbzmeeOnHF4mFqjRnx0XKbQKMsyzh0+g9vXolCmcjlUbVC9SD3nSURE3omhkXJk75+7sPz73zNtS7hzF+92fR3vz/wYweEhCA4LydO5E2MTMPb5D3Ev/p7zg72IzSYh9mYMbl68gbSkVIfHSDYbSpT+d7R5SmIyJgweh/joOMiSDFEUULpSGYyYMRoGX0NhlU5ERGSnaD1ERgVm4cS5DrdbTBZ8NfgzfPD425j6ztcwG3M3J6EkSZg4+LMiFxiB9JHTBzbtwx8/L4csO56svFX3tvDx98n4ef6EXxBzLRrmNBOsZgvMRjNunL+OpVMXF1bZREREDjE0UpYURcGlExewdelfSEtx3FMGpC8DaLNYcWrvcfz6+ewcn99itGBIq/6IuR7tinI90uqfluPWRcdrVKvUKnR9oXvGz7Is48jWg3Yjqm1WG/b+uatA6yQiInKGt6fJIbPRjClvTsC1s1cgywqQg2kFrRYrDm3ej/6jXoHOoHd6/DdvfFHkp5zJbjlERVYQe+sOwsuX+mcDsuyRlIt4OxERkedjTyM5tGrmUlw+dQlmoxlWs8X5C/4hADCmGHN07MXj5/NYXdEgyzKmj/gG5w6fBpA+l2X1xrXsBr2IKhH12jR0R4lEREQZGBrJod1rdsBmseb6db6BfggsEeT6goooi8mCZQ8MMOo/aiB8Anyh1esAADqDDv5BAej7Tj8A6Y8MxN66g3txie4ol4iIijHeniaHJJstdy8QAK1Oi34jX87x9DCRNSvhyqlLeaiuaLl54d9nHsPLlcLEVd9h77qduHXpBsrXqIgWXVtD76PH2UOn8fMnPyAlMRmyoiCyZkUM+XIYQsJD3Vg9EREVF+xpJIcatmsClUpltz2rQBhWpiTe+/FjNGzfJMfXGDZ5RJ7rK0rMRhMmDBwLY0oaAMDH3wed+nTBix8NRPsnO0Hvo0dcdCy+fesr3I2Jzxh4dPnkRUwc/FmWz0ESERG5EkMjOfTUsGcRWCIIOkP6bVKtXgutQQfNA+tJP6h0pbKoXLdKjs//57zVeKfb6y6p1dspioLLJy9i3pdZjzzfvnwzJCnzYBhZkpF89x7OHzlrd76Lf5/Hka0HcS8+sSBKJiKiYoi3p8mhwNAgfL7sGxzYuAdXTl1CqQqlUaNpLXze/xO7Y7V6LWo2qZ3t+UxGE1bNXIrzR89Cq9VmuUJKcWWz2nBo0368PGYINFqN3f7YW7GQrPaPDChIn2T9vrioWEwa+jmS794DBAE2qw2PPP8oer/eh6vKEBFRvjA0UpZ0Bh3a9OyANj07ZGxr0a019m/Yk7GOskqtgm+AH9r0bJ/lee7GxGNkz7dhcxB6vJlGr0VQaCAS4xJhNVuh1qihIH0EuVqrgSzJsJjMOT6fZJNgs1gdhsYajWvi2I7DsBgzn0+WJFSsXTnj5+/enoS4qDsZSz0CwKbF61G5TpVcPTpARET0XwyNlCv9Rw9CZK3K2Pz7BphSjWjYvgl6DHoSBj+fLF8z7d1vilxgBAAoCoZOfBspiSk4vvsooi7dxKXjFyDJEiRJQsN2jXFo837Ithw+cygAxjSjXVsqioKIimWg0WrsQmNIqRIoWS4cABB9NQqxt2IyBUYgfWWaTb+tZ2gkIqJ8cVlovHLlCkaOHInExEQEBQVh4sSJiIyMdNXpqRAc2rQfa+esxL34e6jWoAZ6vfY0wstHZDpGFEV0eOphdHjq4Ryf9/rZqy6u1DP4+PkgsmYlAEDU5ZvYsWJrpp7FY9uPQBREyMhhaFSAEd3eQPnqkej4zCMICAlE+WrlMXvsTFw6fgFWi/18mQkx8di65C906tMFplQjRAeDlwAgLTnrFX2IiIhywmWhccyYMXjuuefQs2dPrFq1Cp988gnmzZvnqtNTAVs/fw1W/rg0I/Qc3LwPx/ccw6cLv8zoycozQQCUHCwp42XSHpjEfO2cVXa3oi0mc/q96ly6fu4q5n42CzqDDlazFRCyXlnGYrJgw4K16NSnC8pWLe/wchqdBo07Ns99IURERA9wyejp+Ph4nD59Gt27p6+j2717d5w+fRp379518kryBBaTBatmLs0UehRZgdloxurZK/J9/tyMqvYmVrMFnz73Ifas3YnkhCTHB+UjK5uNZsiynO1ShACQmpTei6jRatB/9CBo9VqIYvqvtlavQ2ipMHTq2wWJsQlY+eMSfP/eFKyfvxapSSl5L46IiIodl/Q0RkdHIzw8PGNeP5VKhZIlSyI6OhohISE5OkdoqJ8rSvFqYWH+brnutXNXM0LGgxRZxuUT553WlRCbgBWzluPwtiMIDQ/BE4N7oVHbRhn7x87/FK+0fAWm1JwtL+hNrp+7ivlfzobeVw9Tqsluf2CJIJhSjTA/8CyiWqNG5bqVEX87Homxifl+3rNey7oZf0aPPf8IajWqinW/rkX87Xg07tgEnZ7uhFuXbmHU0yNhs9pgtVhxcs/f2DB/NSavmYKSZUrm6Dru+nwWRWxL12J7uhbb03WKWlt6zECY+PgUyHLRu4WZU2Fh/oiNTXbLtSVBA6vV8ZKBQSVDs60r6e49fNLnA6Qlp8JmteH6uWs4deA0nnqzLx7u2/WfowRM3/Yz/py3BsumLS6Ad+BeZmMWI6SF9IFDB9bvwaHN+yGoREhWGzRaDRLuJCLpbhICSwQjMfYuJJvk+BxOiCoRjw95BmePX8GxnUcgigIatmuCZ97tn3FMcooVk4dPgfGB0G42mWGxWDHzk58wZMIwp9dx5+ezqGFbuhbb07XYnq7jrW0pikKWHXkuCY0RERGIiYmBJElQqVSQJAl37txBRESE8xeT2/kHB6BhuyY4tuNw+jN0/9Dqteg+oGe2r10/b01GYLzPYjJj2fTf0KZnh4zJwUVRRKXalTM+H8WBRqtBUIkgDBr/OsxGM07s/RuyJMOYaswIcPHRsRBVIlQatcN5GLMjqkT0Gf4Cju8+iuXTfwcEAYIA/DZ5Pp58rQ/KVimH8AoR8A8KwM2L1+1er8gyju855oq3SkRExYBLQmNoaChq1qyJNWvWoGfPnlizZg1q1qyZ41vT5H4vjxmCXz//GYc274MoitDotHj23RdRs1mdbF93cu9xh7dXBVFE1OWbmeYQ9A30Sw9HXhAaazWrg7OHTzt9njA7KrUa8dHxMKeZcPrACdgsjntzZUmGTquB3kePtKR/RzkrigKtTgv/kAA07tAUm37fkLFdo9WiXuv6qN28Lsa+8BGs/zn371MWQO9jgGSzoW7rBllO7K3V2c8JSURE5IjLbk9/+umnGDlyJH744QcEBARg4sSJrjo1FQKdQYfB419Hvw9fRmpSCkJKhkJUOR8nFVQy2GEvlmSzwT8kINO2clXLI6RUKG5fi3I6QCQ4PAQJdxIKd9S1ADTt3AKP9n8cl09exMXj52GR7Ke5ySnJakNkzYrYsHAtzE4m+baarfj2r5nQGXS4ceEaNv+2AXHRcajbqj7a9uoIg68B3Qc+iYN/7UVqUipqNq2NSnWq4I+flkPKYh5IU1p6b+aJPccQVqZk+qoytn8DvkanQdteHfP8/oiIqHhxWWisXLkylixZ4qrTkZsYfA0w+BpyfHzXft1x/siZjBVigPRVYirWrowSEWEZ28xGE36bvABxUXdyNKI4IeYuWj76EPau2+X02Lzc2nVEq9Ni6JdvAQCCw0Px2+QF9gcJgCAIdhNo/5coimjRrTVCI0pAZ9BDFFWQs+lh1fsZoP1nXe9yVSvgpY8H2x3jF+iHDk91zrRNlmQoToK11WxFQmwCylUth+irURAEAZIko2bTWnh8UO9sX0tERHSfxwyEIe9Uq1kdPPP281jy3SIIYvpAj0p1q2DIF29i9+rt2L9+DzR6LWJu3EbsjRjYLDkMdwJweMuBHB2qyHm/hZzpPA9kr4DgAAyd8BZ+/HAqZEn69xa8kh4aISDbsBYQGoC+776IXX9sR2JcArJb9lmr1+GxAT3ztDZ0407NsGHBmkyh3RFzmgn9Rw+CLMmIuXEb5apVQJlKZXN9PSIiKr4ExVk3RSHh6GnvHGV1n8VkQdSVm/APCkBQWDAmDf0cV05dgtWct9u7gkoAFDjt0XOlgJAAVKlfHTHXoxF/Ox4hpULR/JGWWDVrmd2zjRqdBpXqVMG5w2ccnqt+24a4evpKxnQ7ao06y6l1QiNK4POlX0Or12VbnzHViNhbdxASHgq/wPSRbYqi4MtXPsXFv887fX9+Qf7oP2ogGrZv4nCKpex4++fTk7AtXYvt6VpsT9fx1rYs8NHTRFq9NmNJvcNbDuDq6bwHRgBQpML/B0RSQhKObD2Y8XPUpZtYMcPxIxdWsxUBIYGo3rgmzh85a9frePX0FSTdvZcRerObizHpbhI2/bYBj770uMP9iqJg6fTfsGnxn1Cp02/FN+/aCi9+NBAbF63D9XPXcvT+UhKT8f17U6DSqPDiRwORcOcu7sUlonbzuqjfphFUasdLEBIREQEMjeRCZw6cxOLJ83Hzgv3AmNxSa9WQbLLLbj3nSC5yqiAI8A3wxctjXsWvn/+M/ev3ZAqO9+ISc3wuq9mC3au3ZxkaV/+8Ahvmr4EsyRlTIh3YsBc+/r7YvWaH3fKFzkhWCXPGzsx4FnTPmp0oV6083vtxNDRajqYmIiLHGBopV5ITkrB79Q7EXI9G5XrV0OyRltDqtbh4/Dy+Gz7J6bN1OSXZJKjValgthRgac0GtUaPNEx2gM+jR5+0XcGjz/pw/r+mAIDp+njH6ahRWzVxq15NpMVuwbdmmfLX3/cFDZqMJ189dxYIJvyAtOQ1qrRptenZALSfTLRERUfHC0Eg5dv38NUwcOBY2mw1WsxX71u/GHz8tw8fzxmPFjCUuC4xA+rOM/517MFcE5GvdZ2ckScKJXcdQsVZlXDt3FRqtJs+hUavT4qHHOzjct2TqoiwH3FjNVpQsWwp3bt6223d/UvUsV6v5D4vJgl1/bM+41tFth9GpzyPo0q87tvxvI66cOI/Q0uHo/Fw3BIYG4srpy/AP8ke5ahXyNICHiIi8D0Mj5djsMTMyL0VnNMNmvYsVM5Yg6tINN1aWmSAKEEUxz0vz5YQsyVg79w806dwCwSWDs5wrUaVWQZblrAf0CEClulXxcN8uDndnNdAGAEIiSuC59/vjh/emwPLA86NavRZvfPMuVCoVZo6aluNb5Q+GU4vJjI2L/sT25VtgNVtgtVghqk5hx8qtEEUBGp0GsiQjNCIM70wbiZBSoTm6BhERea/cDaGkYis1KQVRl2/abZdsEg5vOYCIimXcUJVjiqwUaGC8T7JJOLL1IMpVrYCIyNJ2A0k0Og2eHdEf3Qc+mWVvXNkq5fHej6Og1jj+91tWt60B4IX3XkK91g0wfNoHqNaoBgJCAlCjSS28+/1HqN28Lmo0qYURP3yU5wEuktWGtOTUjB5fWZIzph8ypqSPCr99LQrfvv1Vns5PRETehaGRckRUZR081Bo1nhjydMbk1MWFICBj6prh00eieqOaUGvU0Oq1CAgNxGsT30br7m3Rpkc71Gxa2y68afU6PPnaM1kGyvjoOJhSjA73VW1YA/XbNoKiKBBVKrTr1REjZozGsCnv4czBUxjV+12MeXYkzh85i69WT0WjDk3h4++bZTjNK1mScefGbURdueXS8xIRkefh7WnKEYOvAdUb1bRbj1mj06JNz/ao1rAG3pj0DhZ8NRd3btg/Y1ckCUCTTs0BpE8GPmLGKCQlJMGUYkRweAiWTF2EHz74FoIgQhCAkFIlkHjnLtT/rL/d89XeaNC2cZan/3vnEYhqFWQHg4Gq1K2C5IQkTBr6OWJvxgAQIEsSVBoVJKuU0Tv4+7cLcObQKbzx9TsAgGXTf8PaOatc2gwqlQqp91Jcek4iIvI8DI2UY6+MG4oJr4xFckISZFkGIKByvap47OUnAAB1WtXHhJVTkJaShl1/bMOeNTtw48L1Qp2g29UEMZslAxUB/sH+mTYFBAcgIDgAS6Yuxo4VWzKmyAHSp+F58rVnULVhDZSpXBY6gz7ba4tqlcNJuEWVClqDHr+Mm4noK7cy3Yr/7+Ahi8mC4zuP4uaF6yhbtTzqtWnk8tAoyzLKV4906TmJiMjzMDRSjgWHheDLlVNw5sBJxEbFokKNSFSsVdnuOFmSoVKpUKt5XdhsEqIu2T8L6TWyybsarRq7Vm9HfHQcLp+4iDKVy+KRFx5DybLh2PK/DXajyS0mM7Yu24wu/brn6NIN2zXG4km/2m1XqUU0aNsIa2avyNmzmwJw8fh5lK5cFjM/nJqja2dHVInpvc1C+sjvvu+8mDFam4iIii6GRsoVURRRu0W9LPdfPnUREwd9BpvFmj4a18tnY8lulU3JJmHptMWQJRmSTcLlUxex98/deH3S8CxXgLkXn5jjaweGBuGlTwZj7rhZEEQxvRZFQe83nkVYmfAcn0dUqRAUFowrpy4jNTnV4TFlq5bP1aTsZaqUQ+lKZdC5bzdUqV8tx68jIiLvxdBILqMoCr557cvMywd6751pp2xWGxQoGe9RlmRYJDP+9+0C+IcEIPFOgt1rKtSomKtrtOz2EGo3r4sj2w5Btklo0LZxxvQ2ERXLOA16giBAp9ehTsv6OH/0LMQsBt34B/mj1WNtsGftTqc1yZIMH39fDP3yrVy9FyIi8m4cPU0uc/X0ZRhT0txdRqEQRAGiSnQYiqOvROHpYc9nHk0upM+f+Mxbz+X6WgEhgWj/ZCd0fOaRTPMhvjJmCPQ+eqi16f/20+q18A30Q2CJIGj1Omh0GpSpXBYjf/4Eao0aletWgSTZD6rR6nVo2rkFBo57DT/smINKdas4rSk+KjbX74OIiLwbexrJZW550ATfBU1UqaA4CGBA+oTezR9piYCQAPwxaxlib91B+eqR6DXkaVSombuexuxUqFkRXyyfjO0rtiD6ahSq1KuK1t3bQu9rwO1r0dBoNShROizjeJ1Bj34jB2D+hF9gs9ggyzJ0Bh1KVyqD1t3bAgD0vno89Hh73Dh3LcsVeQQhfQCUI2ajCX/vPAqz0YTaLeohJJyTfhMRFRUMjeQyZauWhyAI2T4HWFTcX7f5v6OrNVoNWj7WBqJKRO3mdVG7ed0CrSMoLBg9B/e22x4RWdrh8a17tEP5GpHYtmwzku7eQ6P2TdC0c8tM8zdWqVctfRLKLGj1OvR89Sm77WcPncZ3wyelr+CoKJAlGd0H9kKPV3rl/o0REZHHYWgkl6lQoyJCSoUiPjrO3aUUGkVWoFKrIAgCZFlBtUY18Oy7L7q7rGyVq1oB/Ua+nOX+slXKoVH7Jji6/TAspn/Wrv5nIvN6rRug9xt9Ufo/KwAZU9Iw5c0Jdr2Ta39ZiVrN6qByXcc9k0RE5D0YGsllBEHAm5PfxafPfujuUgrV/Wlv1FoNLv59HuePnEFQyWCUKF0SBl+Dm6vLuYTYu1g+/Xf8vesotHot6rVugLioWFgtVnR6qiNa9mjvcG5JWZLx5SufOrydbTVbseuPbQyNRERFAEMjuVT5apHQ+ehhTjO5u5RCZ7NYYQMwZdhE6Hz0kCUJnfp0wdPDnstyqcCckCUZ189fhahSodw/jwC4WmpSCsY+/xFSEpMzVvxJSUhGg3aNMeTLYQgL80dsbLLD1/696whuX3e8CpCiKEhOTMG0dyfj3JHTMPga8OhLPdHhqYdd/h6IiKhgMTSSU/s37MHsMTMy5h70C/LHmAVfIDSihN2xNqsNFqO5sEv0OPdD85b//YWgsBA88ly3PJ3nzMFT+PHDqbCaLVAUBb4Bfnjzm3ddOqAGAHas3ApTijHTEpEWswVHtx/CnRsxCAvzz/K1J3Yfgy2bQTNHthzI+DktKRXzv5yNU/tP4I1Jw133BohywGaz4dLlqwgM8EepUjmf65SI0nHKHcrWtXNXMPOjaZkmq05JTMZ73d90eLwgCAXSE+atLCYzVv64BB/1fhfvP/4WZo+Zgdhbd3L02nvxiZg6fBKSE5JgSjPBbDTjbkw8vhoyHmYXB/MLR8/BYrbYbVep1bh+/mq2r/ULCoBKrXK4L6tBUUe2HMDLjZ/FkNb9sem3P3NdL1FurV69HnXrt8Zj3Z9Bi1ad0at3P8TFxbu7LCKvwtBI2Zo16vss933Q8y0k3LmbaZtKrUJIKfseyOLMlGrE7atRiLt1B7vX7MDInm9j0pDPcWLv39mGv73rdmXq+btPlmUc3XbIpTWWiiztMPgpsoyAkCCsX7QeM0dNw4oZS3A3JvNftA/1aAdR5Tg0OmMxWbBo0jxsWbIxT68nyonjJ07hreEjkZh4D6mpaTCbLTh06Cie7zfY3aUReRWGRspW7K2YrPfdvIP3ewzDurl/ZGxb/sPviIvKWU9acaUoCs4cPIkpb0zAGx0GYtNv6x0el3T3nsPBJZJNQnJCkktr6vh050zT7gDp/wAoWS4cP3/yPX4e9xP2r9+DP3/9A6N6v4sLx85lHFeyXDgGffYadD56GHwN0Opzvw7175MX5Ps9EGVl1k+/wvyfnnSbzYYLFy7j7NnzbqqKyPswNFK2BFX2HxHJJmHp9MX4e+cRXD9/DRvmry2kyooGyWrD71MW4OcxM3B026GMkdgAULNpbYejlUVRQPXGNV1aR4nSYRg8/g2EhIdCVKug0qhRt1V9VKpbFQmxCTCnpfeI2qw2mI1m/PTx95luPTfp1Bzf/TUTb3z9Dl7+9FVodJpcXd9qsWLCoHE4tf8EbFYb7sUnOuxlJcqLmzejIMv2nye1Wo2YO1zdiCinOBCGstXy0dbYsWxr9gcpwHdvT4J/aECWq4hQ1iSbhD1rduDIlgMILBGEUXPGwS/IH7Vb1ENk7Uq4cvIiLKb0XhKtQYcGDzVC+eqRLru+zWrDL5/+iENbDkCj1UAUBDTq0BQDx72GkT3fzpjI/EH34hOREHM3Y1lDm9WGI9sO4ui2Q/AL9EdQiWDERcXmaqL380fOYMqb5yH8MyekVq/Fk6/35Uhryrd2bVvj2LETMJszPw5isVhQt04tN1VF5H0YGilbvYf2dR4a/5Ec79pbpsWNKc0E043bmPHhVLw3YxREUcS70z/EzpVbsWftTohqEW2f6IiWjz7k0uuumPE/HN56MH3KoH9C/7Hth7Fq5tLM62c/QJGVjN5Em9WGr179DDfOX4PZaIYoilCpVdD76qEoChRZgSTJKF2pDK6fu+pwve77ZCm9p1WCBKvFit+nLIBfoB+adm7h0vdMxcuAl57Dr/MW4+7dBFit6Z9xH4MBgwa9iJCQYDdXR+Q9GBopW/7BAShdqSyiLt90dynFgwKcOXASi7+ZDx8/A5ITk1G3VX18+MunEMWCeZpk29JNsP7neS+L2YKtS/7C46/2xvLvf8/o6QQAUSWiUp0q8A8OAADs/XMXrp+7lrF6jCzLkC0yBEHAoPGvwZhiQtUG1RBePgJ7/9yNnz6enm1wzFSHyYw/flqGpp1bwGw04cDGvYi+EoVy1SqgSadm0Ogch1qiBwUFBWLTxhX4/oefsXHjFgQHB+HVwQPQvXsXd5dG5FUYGsmp8UsmYcnUhfjz1zXuLsVr5XZN7r8WrYNKrYJkk7B9+WYElgjGy2NeRc2mtV06pZGiKDBlMRG7MdWIDk91xqW/L+DvXUcgCCIEAQgIDcSrX/w75dLBjfv+XW7wASq1Clq9Do07Ns/Y1rJbaxh89Vg6bTGiLt/KUY13Y+4iLioW4/uPhtlohtlohs6gw/IffsfoXz9DYGhQ7t40FUslSoRizCcfYMwnH7i7FCKvxdBIOfL0sOcRWCIYv30z392leJWA0ECElS6Jtr06Ys5nM3Pcwwb8uzyhZJNw93YcpgybgGadW2LguNdcFhwFQUBkrUq4cuqSw/2LvpqLoRPfguleIo7sOoGQ8FBUa1QjU6+nwc/xUomKojgcyNOgbWM0aNsYh7ccxE8ff+8wcD6ofLUKmPPZTCTd/ffxB7PRDIs5/fb14PFv5OStEhFRPnH0NOXYI889ik8XfQlB5OTdOZUUfw8RkaXtglZeSFYJBzftx6l9J1xUXboXPhjgeI5GRcHutTuRcOcuylUph1aPtUGNJrXs3kf73g87nGZH56NHlXrVsrxu445N8eTrfaAz6KH30UOlVtl9ttIHwzyDMwdO2dcnyzi4aV9O3yYREeUTexopV8pXj8Qn8z/H2Oc/cncpXmPX6u3pz/m5YAoZm8WKqe9MQni5Umj1WFs83LdLvp/rq1i7MiJrVsSlExft9mk0atw4fw3ValfI8vU1m9bGYwN6Ys3sFVBpVAAEaLQavDN9JEQnUzY98lw3dOjdCXdu3UFgSCCO7TyCpVMXI+VeCoJKBOG5915CZM3KWb5eskpQFIWrEBERFQL2NFKuVahRET/snOPuMrzKnrU7XXYum8WGW5duYsnURRjZazhsNvspcXKrfPVIhwFPkiSHa4z/V4+BvfDVmql4afRgvDbxbUxe/wPKVc06aD5Io9OiTKWySE1KwW/fzENaSipkScK9+ET89Mn3uHDsbLavv301KkfXISKi/GFopDzR++gxdcusXE/iTK6VEHMXP344LdtjLCYLTu0/gXNHzmSaPPxBDz/bzW5FGLVGjfLVI1Gmcrkc1RIYGoRmj7REnZb1slyLOjuLv5kPY4oRNkt6CJZsEsxpJiyZtjjLnkRBEKBSq5FwJwFzxs3EZy+OxoKJcxBz43aur09ERNkTlNwM6SxA8fEpkGWPKMUtwsL8ERub7O4ycu3K6Yv4rN/H7i6j2PML8keNJrVQu0VdJMQkwGqxolGHJki4cxezx/z4z7OCCtQaDd769n1UrlvF7hxnDpzEnM9mITEuEVAU1GvdEC9/+ip8/H0L5fM5pFV/WP4z9Q+QHgzrPdQAf+88arcvJDwUT7/1HGaOmpZpkJFGp8GIH0ahaoPqBVlynnjr77qnYnu6FtvTdby1LUVRQGion8N9DI0ewls/XACwdPpirJvzh/MDySMY/AyYsuFHhxN3K4qCpPh70Bp0MPj+Oyq6MD6fQ9sMgNnB9D9qjRpfrZ6KsS98iHtx99I3Cum93e9MHYkJg8Y5XCIuIrI0Pl/2TYHWnBfe/LvuidiersX2dB1vbcvsQiNvT1O+PfXGswivEOHuMjxCaGnnz/+5myIrOLbjsMN9giAgsERQpsBYGKwPrEbzXyXLlcKYZ0fCmGIEkD65uFanw8ifx+DK6csOAyMA3L5+G8aUtAKrmYiouGFoJJf4aPanQDEfwCqqRExaPQ2T1kyzez7Qk8iyjLTkVHeXkcnNC9eh1jp+PvZuTBxS7iVnrEojSzIsZjMWTpybfis9C4KALM9JRES5x9BILuEfHIDJf/7g7jLcSqNNv90bGlECH/z0CcLKlEx/llAQ4BvouKvfHSSrhFrN6rq7jEx8AnyhZDElkdlohvLfR1cU4OLx86jWsHqWg25qNa8LDUMjEZHLMDSSywSFBWPmvnnuLsNtDH7/rn5SuW5VTPzjO3y78Uf8sOMXTFz1LUqWLenG6v4lSRI+efYDTBw0DpeOX3B3OQCA8HKlEFGxtN20P1qDDtos5qEURRG1W9ZD5frV7CYc9w/2x9AJb2V5veSEJKQket+zRkRE7sSBMB7CWx+YzYokSVgydTE2Lljr7lIKXYenH8az7/a3u0UtyzLWz1uN5TP+B9mW/4m+XaVem4Z4ZexQ+Af6Z3lMYXw+78bEY/IbExAfHQtRpYLVYkX3l59A6r0UbF22KdMzj2qNGo07NcOrn78Jm9WGHSu3YPuyzbBZJbR4rDUe69/T4byTty7fxKxR0xF15RagABVqRGLw+DdQslx4gb63BxW133V3Y3u6FtvTdby1LTl62gt464fLmbTkVCyZthiHNx9AWnKqS1ZF8RaPD34SbXp2wPWzVxFz/TbKVi2PWs3rQJEVXDl1AfO++AU3L95wd5kZfAN8MXreeISXK2W3r7A+n4qi4Pq5q0i+m4TI2pXhF+gHs9GMb9/6CldOXcL96RpLRZbGezNGwcffN8fnNqak4b0ew9Kf5/znq0YQBPiHBGDSmmmFdiu7qP6uuwvb07XYnq7jrW3J0OgFvPXDlVffDf8af2cxgreoUWnUgKJArdWgZNlwjPzpExj8fAAAt69HY+OCtThz4BTibsdBsuZ+dRe1Vg21Rg1Tqv10NbklqkR8v302dAZ9pu2e8Pm8duYKbl68jlKRpVGpTpVcLx24fflm/DZ5PsxGc6btOh89Bnw8GM0eaenKcrPkCW1ZlLA9XYvt6Tre2pbZhUbPHeJJRdpbU0bAZDTh0vELmD1mBhJjE9xdUoG5HwQlm4ToK7ewdPpv6DfyZQBAqfIRePGjgQDSe9k+6fsBbuWi99HH3wdd+nVHtxd7QFSJds/2/bX4T/w2eb79QJIsyJKMnau2o1y18ggJD0VYGdc/h3nx+Hn89s18XD9/Df5B/nj0pcfR8ZlHnIbACjUrokLNinm+blx0rF1gBNLX846/HQcgfdDNgY17cPnkRURElkGr7m3h50GDmIiI3IkDYcht9AY9ajeviw9nf4qyVcs7fAatqLFZbdj35y6H+wRBQPsnOzmcdDsr9ds0Qo9XekGtUdsFRgDo/Gw3BIQE5qrGRZPm4ru3J2H00yMwaejnLp3r8NqZK/h66Oe4fPIibBYrEu7cxZKpi7Fq5lKXXSMrFWtVhs5Hb7ddrdUgsmYl3ItPxKin3sWiSb9i+/ItWP7D7xjZ8y3cunyzwGsjIvIGRf9vafJ4YWVKYtxvE/HFssn4dPEE/LR/gbtLKlDGFGOWk2u37/0wajWrC61eC0ElZjv3pVqrQXh555OqV65TNdc1mlKNsJqtOHvoFH7+ZEauX5+VlbOW2i0VaDGZsX7+Goe9gDkhSzIuHDuHU/uOZ3uO+m0aIax0GNTazDdYrCYL9qzdicVfz8O92MSMc1hMFqSlpOGXsTPzVBcRUVHDZxo9hLc++1DQZn3yA/at3enuMgpE2aoV0O7Jjmj/ZCe7uQavnL6Ei39fQFCJINRr0xBj+n6AuKjYTAOJdD56fLl8MoLCgrO9zvXz1/D5Sx/Dana84kpOdHqqEy6duoLAEkF45PlHUbNp7TydZ8Rjb+Du7Xi77TofPcYs+AKlcrmy0PVzVzFl2ESY00wQBAGyLKP/6EFo0bW1w+ONqUb8MWsZNv22HpJNytiuUqsgSzIcfR1m9ZxnXvF33bXYnq7F9nQdb21LLiNIXmvwuNcw8ucxuXqNVq8roGpc6+aFa1g4cQ4GNX8BR7YdwrkjZzICVcValdH52a5o2rkFdHodPvjpE1RtUAMqTfqgl1IVIjDih1FOAyMAlK9WAe/P/BiRtSvludbNSzfj6pnL+HvnEXz39lfY/PuGPJ0nokJph9tlScrRe3mQzWrDpKGf415cIkxpJhhTjTAbzZg7blb6lDoOGHwNaNi+id10SJJNchgYgfTHBhzd+iciKm44EIY8XrWGNfDL4cUAgJR7KVgwcQ4ObNhjf6AAfLroSxzdcQirZizL0bkFQfj3WUpBgCLLgIIs1zMuKNPf/QZA+vyDdVs3wKufv5np2cbgsBB8MOtjpCalwGaxIbBEUK7OX7luVXwy73MsmDgHW/63MV+1WkwW/D5lAe7FJ0IQRDTu2BTlq0fm6LWPD+6NC3+fy1gSEAC0ei3a9uoIvYPnDbNzcu/fmXoL77PZbNi5civ6DH/B4etunL8GKYupnwRRTP8M/EOlVqF2i3rQZDHBOBFRccLQSF7FL9APQ754E0O+eBMA8Ov4n5GUcA8vjR4E/+CA9GNKBOQoNIaVLYnazeui1WNtEVmrEtKSU+Eb4IekhHt4t9vrGXP5FSab1YZjOw5j8Tfz0H/UQLv9vgH5G8nb8ZlHsG3ppnyHYpvVhjWzVwIAVv+8HDWa1MKIH0Y5HcxUtUF1vD5pOBZ+NRexN+9AZ9Ch83Pd0HPwU7muIS05zeGocFmSkZzNai9hZcOhVqsyTRYOABqdFsElg3EvLhGyrEClEhFYIggDPhmc69qIiIoihkbyav1H2werkJCQHL227zsvomG7xhk/3x9lfOPcNRh8DDCmGvNWlAAElwxBQszdPL1ckRXsXLkVaq0aJ/f8Db9Af3R54TE07tQs13MT/lfpimVQtmp5XD93NV/n+a+zh07jjQ4D0e3F7ujUpyt8/H2yPLZuqwaYsPJb2Kw2qNSqPL+nGo1rQZLsexp1Bh0atG2U5evqtKgH/+AAWMxWyP+8XhAEaHVafDzvc9y+FoUb568hrGw4ajatzVvTRET/4LchFUnv//BBtvtDI0pkCowPCgkPdRhGckoQBHyz7nvM3DcPz454MdsR0FmRZRmbf9uAmOu3cenEBfz86Qys/HFJnmt6ULWG1V1ynv8ypRqxYsYSfNjrbaQmpTo9Xq1R5ysEh5QKxSPPPwqt4d9nWLV6HSrUqIiG7Zpk+TpRJeKjX8aiTou6UKlVEFUiKterio/mjIVvgC8q162K9r0fRu3mdRkYiYgewNHTHsJbR1l5qvvtOWnoeJw9fAY+fj4wp5kgqkQ07tgMAz5+1W7qlQd99uJoXDt7xW7Zw7LVyiPuVixM2fRCVq5bFaPmjsv4WZZlTBoyHucOn8nXe9JoNfhm/Q/5nmz6xoVr+KzfaNgcrD4TFBYMY0panqe/uU+r16Hn4N7o/Fw3u0EnrnZyz9/YtnwzTGkmNO/aCi27PZTja1otVsiSDJ3B8eAps9GMw1sOIP52HCrWrIRaLfIfJPm77lpsT9die7qOt7YllxH0At764fJU+W3P+Og4jOz5tl2Po8HPB1+vnYZZo7/H3zuP2L9QAL5aPRUlIsLsdi2b/hvWzlmV55qA9EFBb099H3ofQ77Os2nxeiyZugj3F3MWRQHDJo9AzWZ18O3bX+H4zqP5Ov99/sEB+HLFlGxvV3uq29ei8cXLY2A1W2AxWaDV61C6Umm8P/PjfE2/w99112J7uhbb03W8tS0ZGr2At364PFV+23P3mh1YMOEXux43rV6HZ9/th3ZPdsKJPX9j0aS5iLsVCwhA1YY1MHDsUISEh2Z53qgrN/HN61/m+XnH+0IjwtDn7efR5OHmeT5H0t17OLXvBDQ6Deq2apDR23bpxAVMGjI+0wjnDAJQulJZRF3K+Sop4eUj8OmiL1w2z2FhGffCR7h29mqmqXjUGjXCyobDlJqGoLBgdH+5Fxq2z/pWuCP8XXcttqdrsT1dx1vbkqHRC3jrh8tT5bc91/6yEstnLMk0/cp9PV/tnafRvg+Kj47DrtXbsGHBWphSTXk6h1avRb8PX0Hr7m3zVYsjf+88ggUT5yAxNgGCKKJpxyZ49JUnEVGhNESViKPbDmHu+J+QnJCUo/OVrVIeoaXDcPvqLZQsVwqPPNcNtVvUc3ndeXH7WjTiomJRrmr5jKmMkhKSMKLb6w5v4T9Iq9fhqTf64uFnu+b4evxddy22p2uxPV3HW9uSodELeOuHy1Pltz3PHjqN797+yq6nUWfQ4fVJ76BOS9cFnuN7/sbCib8g9uYdAIAgCg6nknEkqEQwvln/fb5HVTuiKAqMKUZo9VpElA62a09FUXBk6wF8/963uT63RqfFE68+hW79e7io2txLS07DtHe/xpWTl6DSqGG1WNHm8XZ4/oMBSLmXkqPQCAB6Xz2+2zQLGq0mR9fl77prsT1di+3pOt7altmFRk65Q+RA9cY1EVm7Mq6cuJixVrJGp0W5ahVQq3kdl16rXqv6qLfqO6Qlp+LvnUcQfzsOK35YkuUKJQ+6dzcRNou1QCafFgQh22cRBUFA447N8cbX7+Cnj7/P1eAZq9mClTOXoN2THeHj7+uKcnNElmXsXr0dW5duQsy1aJiMpvSA/s+f8e41O1C6cjl0euYRlK5cNn1qIid/DIoCxEXFIiLS8Wo3RERFBeeTIHJAEAS8M20knhj6DCIqlkFEZGn0HNwb780YVWDTsPj4+6Llo23Q/eVeaNHN8drJdq/x84U6hz1cBaVRh6aYvm022vXulKvXiSoVzhw6haT4e7hw7Bwu/n3e4QovrvTzJzOw8KtfcfX0ZRhTjXY9uhaTBZsW/QkAePXzN+EX4Jf+LKaQ3gPsiGSTEBASUKB1ExF5AvY0EmVBo9Wga7/H0LXfY4V+7UGfvY6QUiXw569/2E37c59Wr0OPgb0K5NZ0bqnUKvT/aCDa9OyA8S+OztFrzGkm/PD+txnBTRAFqNVqDPzsNTR9uIXLa7x1+SYObzkAq9nBAJ8HpKWkAQAiIktj0tppOLRpP+Kj4yCIItb8sgJW878ryWh0GjRq3zTfK/UQEXkDhkYiD9X79T54fNCTiLp8E1GXb2Hf+t24cPQsLCYLDH4GdH+lFzo/183dZWaQJRl/zl0FlVoNyeb8WUAAmXr6FFmB1WLFjA++w5+11+CdaSPzPSflgy4eOwdn+VoQRdRuUTfjZ51Bj9Y92mX8HBQWjN+/XQCbxQZZltG4Y3O8NHqQy2okIvJkDI1EHkyj1aBCjYqoUKMiWj76EBRF+WfOQG2Oehgv/n0eu1Zvg9ViQ7POLVDvoYYF1jN5YONenNh7PMeBMTtXT13C8C5DMWHFFIRGlHBBdUBgiSCIKlWW+9VaNXQGPZ58vU+Wx7Tp2R6tHmuDuzHx8Av0g8HP++afJCLKK4ZGIi8iCEKWq5f818ofl2D9/DWwmq3pI523HED9No3w6hdvFkhw3PXHNljyuZLMgySrDd+89gX6fzwIletWzffKMnVa1odOr4M5zZRpkJGoElG+eiTqtKiHTn27IDA0KNvzqNQqhJUpma9aiIi8EUMjUREUFxWLP39dDavl3+fvzEYzju08grOHTqNm09quv2gWQVStVSOkZAgS7iRAVKf39FlNFsgO5sD8r9vXo/HV4M+gM+jwxjfvolazvI9cV2vU+OCnTzDt3W8QHx2bHsB99Hh1/BuomY/zEhEVFwyNREXQyX3HHY72tZjMOLr9UIGExoceb4dLx887mNtSj8+XTUZibAKMqUaEly+Foa1fyvF5FUWBKc2E796ehElrpyEgOO8jlUtViMDnS79GzI3bsJqtKF2pTIGNhi9IQupdaK4chJgSDym0AqwVGgHa/C0tSUTkjPd9WxKRUzq9DoKDMKRSqfK9bnVWmj3SEnVb1YdWr4OoEqHVa9N7CCcNh0qtQmhECZStUg5qjTpHvYz/JUsSDm7c65Jaw8uVQtkq5bwyMIrx1+Cz7UdorhyA+s4FaM9tg8/W7yGYvG8SYSLyLvn+xly1ahV69OiBWrVqYcGCBa6oiYjyqUHbRumzTv+HqFKh1WNtCuSaoihi6MS38d6Po/DEkKfRZ/gLmLR2Oqo3rpXpuHtxiXl6PlGySUi5V8yDkaJAf3QVBMkKQUkP3oJsg2AxQnN2q5uLI6KiLt+3p2vWrIkpU6Zg1qxZrqiHiFzA4OeDNyePwPR3v0l/1lBRIEkSXvhgAEpViCiw6wqCgMp1q6Jy3apZHjN9xGRIUu4n8dZoNajZtHg/eyiYUyGY7Nf7FhQZ6pjzyH4GSiKi/Ml3aKxWrRoAeOVtHqKirFazOvj2r5k4tf84bBYbareoW6hL9jkSFx2LGxeu5Xht7fsEQUCdVvVRtUH1AqrMOyiqbFb/Ubl+KUkiogd5zECYrBbHLk7CwvzdXUKRwvZMV6ZcB5ecxxXtmRIbC7VanWlVleyo1CqULFsSfYb1Rfte7aH6zzyLkk3CwS0HEXUlChWqV0DDtg294h+weW9Lf5jLVIN86zwgP9Bbq9JAW7cNfIvpZ56/667F9nSdotaWTkNjr169EBUV5XDfnj177L7E8yo+PgVyLnsfipKwMH/Exhbz57VciO3pWq5qT31QsMM5IgVBgKgSIUkStFotIAgYNuVd1GhSG0e3HcLWlduxdeV2PNSjHRp1aApBEHAvLhGfvzwGKQlJsFqsUGs1MPga4B8cAFmW0aZnB7Tr1THH81oWlny3Ze3uMCQtgJgSl/7ogSzDFlELKSXrA8XwM8/fdddie7qOt7alKApZduQ5DY0rVqxweUFEVDypNWq8OGogfhn7I6wWKxRZgUanhV+QH1788BVcO3MFvkH+aNa5BfyC/PHT6O9xdPuhjGl8zh48hYbtm2Dw+Dfw6xc/4+7teMj/PB8p2SSY00xIjE0AAPz2zTxs+d9GjF08weOCY75ofWBsOwjivdsQjImQAyOg+AS5uyoiKgY85vY0ERUPzR5pifBypfDXb+tx93Yc6rZqgHZPdoKPvw/qt2mUcdzlkxdxZNshWEz/zvtoNppxZOshXDpxAcd3HcsIjFm5c/M2dq3ejk7PPFJg78ctBAFyUAQQVHCDmoiI/ivfoXHNmjX46quvkJSUhM2bN2PWrFn45ZdfUKVKFVfUR0RFUIWaFTFw7NBsjzm1/0SmFW3us1mtOLX/hMMphewowN51O4teaCQicoN8h8bu3buje/furqiFiCiDj78vNBo1LObME8moNWr4BfihZrPaOHPglNOJwt09YpyIqKjw/GGGRFQsNe3cAnC4nLWApp1boP/oQfAL9nf6vOJjA3oWSH1ERMUNQyMReaSA4AC88fW7MPgZoPc1wOBrgMHPgDe/eQf+wQEoERGGiau+wwsfDECXFx5DcMkQu5D58LNdUb1RTfe8ASKiIkZQlJw8GFTwOOWOdw7N91RsT9dyZ3taLVZcOHYOAoCqDWtkuQShZJNwdPshHPxrH/Q+enTr/7jT1W/iomNx8K99sJqtaNCuMcpXq1AA7yAzfjZdi+3pWmxP1/HWtszXlDtERO6k0WpQq5nz5QNVahWadGqOJp2a5+i8u/7YjvkTZkORFUiSjHVzVqH9Uw+j7zv98lsyEVGRxNvTRFTsJCckYf6E2bCarbBZbVBkGRazBduWbcalExfcXZ5LmExm2Gw2d5dBREUIQyMRFTvHdx9zuNyg1WzB/g173FCR65w4eRpduvVGlaoNUblqQ7wx7H0kJ6e4uywiKgJ4e5qIih1BENKX4Mtqn5eKirqNJ3v3Q0pKKgBAsshYvXo9rl+/iT9WLnJzdUTk7djTSETFTr2HGjpcTUaj06BF19ZuqMg1fp23GJb/TIhusVhw8uQZnDp11k1VEVFRwdBIRMWOX6AfBnzyKtQaNdQaNVQaNTQ6Dbq88Bgq1q7s7vIyEeOvQ79nHnw2fAP93vkQE25meezZs+dhsVjstqvVKly5crUAqySi4oChkYiKnfjoOPzx03KIKhEQBCiyjDY9O6DX0GfcXVomqjuXYNi3AOq4KxDNKVDFXoZh969QxV1xeHzDhvWg19tPdm61WlGjRrWCLpeIijiGRiIqdqa+8zXuXL8Ni8kCm8UKWZKx64/tOLbjsLtLy0R78k8I0r+3mwUAgmyD9uQGh8f369cXBoMh0yAfvV6Htm1boUqVSgVdLhEVcQyNRFSs3L4WjZhr0XZrVltMZvy1eL2bqnJAUSCmxDvcJSbHQky6AyE1IdP20JBgrF+3FF27dIKPwYDQ0GC8OngAfpr5XWFUTERFHEdPE1GxkpacClGtAsz2+1LvpU9Nc/rASayY8T/EXL+N0pXK4snXnkG1hjUKt1BBADQGwGq036fIMOycDSgyZL8QmJr2heIbDAAoX74sZv88rXBrJaJigT2NRFSslKtWAYD9kqUarQaNOzbFsR1HMHX4JFw6fgEpick4f+QMJr/+JU4fOFnotVoqt4Si0mTapuCf29SSBYJsg5gUC8PuuYAiOzoFEZHLMDQSUbGi0WrQb+TL0Oq1EMT0ORm1ei2CS4agU5+uWPzNPFhMmUcgW8wW/D5lQaHXaq36EKwVm0NRadL/E0SkR8Z/CVAg2ExQxToeHENE5Cq8PU1ExU7LR9ugdMWy2PT7BiTciUe9hxqi7RMdodVpEXszxuFrbl3KeqqbAiMIsNTqBEv1thBMKdCe3QLNLQc9nooCwcxVX4ioYDE0ElGxVKFmRbzy6ZBM2xRFgW+AH1KT7ANYYGhgYZVmT6WB4hsMqWQVqG+fyzSiGgCgKJCCy7mnNiIqNnh7mojoH4IgoNtLPaD9z1yHWr0W3V/p5aaq/mUrXRuyTxAU8d9/7ysqDaxl6kDxC3FjZURUHLCnkYjoAd1e7AGL0YwNC9ZBlmWo1CK6v9wL7Xt3cndpgEoNY5tXoLm0D+pbpwC1BtbIprCVq+/uyoioGGBoJCJ6gCAIeGLI0+j+Si8kJybBPygAao0HfVWqdbBWbwdr9XYFcvqTJ8/g+IlTKFumNB56qEWmicKJqHjzoG9CIiLPodaoERxWfG75WiwWDHjlDezdewCAAJUoIiysBJYvm4dSpcLdXR4ReQD+E5KIiPDDjNnYs+cAjEYTjEYjUlJTcf3GTQx7a6S7SyMiD8HQSEREWLhwCUwmU6ZtkiRh3/5DSE7mdD5ExNBIREQAzBaLw+2CAFisVof7iKh4YWgkIioKZAlCSjxgcbBWdQ482q0zNA4G/FSsWAGhIcH5rY6IigAOhCEi8nLqKwehO7MpfWFqRYItogbM9XsCao3T19733nvDsHnLDty9exdpaUbodDpoNGp89+2EgiuciLwKQyMRkRdT3T4P3em/Mq0So44+B+APmBv3zvF5fAwGvPvO69i8ZQdSU1PRonkTPNu3N8LCShRA1UTkjRgaiYi8mPbCTrtlBQXZBnX0GZitJkCjd3qOCxcv44lez8NsNsNstkCr1cBkMuPVwQMKqmwi8kJ8ppGIyIsJpuQsdogQzGk5OserQ4YjISERqalpsNlsSEsz4ujR4/jpp7muK5SIvB5DIxGRF5NCykERBPsdggjFJ9Dp66OjY3D58lUoipJpu8lkwuLfl7uqTCIqAnh7mojIzYS0e9Ce3QJV7CVAY4ClUgvYKjRKn+/GCUv1DlDHXIBis0BAevBTVBqYa3UGRJXT18uynOVlZFnO1fsgoqKNPY1ERG4kmFJg2D4T6psnIJpTIabEQXdqA7SnNubo9YpfCNLaDoatbF3IhkBIIeVhavI0bJGNc/T6MmUiULZsGbvtep0OTz/VM1fvhYiKNvY0EhG5kebyPgjSv72EACBIVmiuHoKl6kOAztfpORS/EJgb9cpzDT/+MBlPPtUv43lGX18fVKlSCUOGvJzncxJR0cPQSETkRqr4axBkyX6HqIIqKQZSWKUCr6F27Ro4uH8LVq5ai+joGDRuVB8dOrSBSuX89jYRFR8MjUREbiT7hkJMuJWppzF9hwTZEOSaa8gy/rdkBebN/x1Wqw29n+yO/i8+B4Ph3+l4AgL88WK/vi65HhEVTQyNRERuZK3cEuro08ADcy0qggpScFkofiEuucZrb4zAxo1bYTSmLzF48eJlrF69HqtWLoJazb8GiChnOBCGiMiN5MBwmJo8DVkfAEVUQxFVkEpVhalZH5ec/8yZc9iwYUtGYATSp9M5d/4i/tq0zSXXIKLigf/EJCJyMym8KtI6vw3BlAxFrQM0Opede//+w8B/b30DSE1Nw65de9Gt68MuuxYRFW0MjUREnkAQoBgCXH7aEmGh/9yCNmfartNpUapUuMuvR0RFF29PExEVYZ0f7gCtVmu3XaVS4Zmnnyj8gojIazE0EhEVYTqdFsuXzkNkZHn4GAzw9fVBWFgJzJs7A+HhJd1dHhF5Ed6eJiIq4qpXr4o9uzbg4qUrsFqsqFGjKkSRfQZElDsMjURExYAgCKhapeAnCieioov/1CQiIiIipxgaiYiIiMgp3p4mIqJCpEADM0TIsEEDCRp3F0REOcTQSEREhUIFK3xxL9M621ZokYYAAIL7CiOiHOHtaSIiKgQKfJEEUVAgCMj4TwMLtP+ZeJyIPBNDIxERFTgREgTIdtsFAdAhxQ0VEVFuMTQSEVGBExysf32fCAUibIVYDRHlBUMjEREVOAnqbGIjoIWp0GohorxhaCQiokIgwAwDlOySIxF5NIZGIiIqFBYYstxnha4QKyGivOCUO0RElCcCZGhhhAo2SFDDAgOUbPoiFKhghC8MSmqm7RboIfGvIyKPx99SIiLKNRE2+CMRQPoUOopigQ5GpCAYMlRZvs4CH9igzXiG0QrdP4GR8zQSeTreniYiolzzQTLuB0bgn3kXoUCfxfQ5AmQYkIwAxMEPiQAAE3z/WREm74HRbDZjwYLf8UyfAXh54JvYvmN3ns9Fnk1RFCxctARNm3dExcr18Vj3Pjhw8Ii7yypW2NNIRES5pEAFW0ZgvE8QAI1isTtWDQt8kAzhgZCpU4xQw4oUBCGvodFisaB9x2dx8uRZGI1GAMC2bbvw2tBXMOLdN/J0TvJc06b/hG+/m5HxZ33k6N/o++zLWL50Pho0qOvm6ooH9jQSEZHLKJkCoAJf3IMvkjIFRiA9YKpggxrWPF/rj9Xrcfr0uYwQAQBGoxHTv5+FO3di83xe8jxmswVTp/2Y6c8aAIxGEyZO+s5NVRU/DI1ERJRLAizQ2U2foyjpg1ru0yK9N/H+koGOqPIxqffGjVuQmppmt12j0WDfvkN5Pi95njt37kDJYr6m06fPFnI1xRdDIxER5ZoRfukTdiuArAhQFMAGDUzwzThGC3OWYfG+7AbNOBMaGgJRdPzXWGBQQJ7PS56nRIkSkGXHobFSpcjCLaYYY2gkIqI8EJGCYKQgCEb4IRnBSM3F84mKAigQYYU2zxX0e6EPdDr7+R1lWcGI9z5GoybtMO6zr5CUlJzna5BnMBj0eKn/szAYDHbbR7zD51cLC0MjERHlmQQNrNBDdjCu0tEtbAD/9EqqkZyPQTAAUKtWdXw//QsYDAb4+/vB19cHWq0WNpsVN29GITo6BrN/WYDuj/eFxfLfATrkbUaPGoEhQwbAz88XoiiibNky+H7612jduoW7Sys2BCWrhwQKWXx8SpZdz8VBWJg/YmP5r2FXYXu6FtvTdYpXW6YPhHlwsIsCAakIgJSPHsYHhYX549q1GBw+/DeuXb+BT8Z8aTdYwtfXB5O//hyPP97NJdcsyrzh8ynLMiwWK3Q6LQRnzz+4kTe0pSOiKCA01M/xvkKuhYiIig0BqQhECgJhgg+M8EMSQlwWGO/z8fFBmzYtYTKZIEuS3f7U1DQcOnzUpdck9xFFEXq9zqMDY1HFeRqJiKgACZCgdXlQdKRMmdLQaDUw/+dWtMGgR4UK5Qv8+kRFHXsaiYioSHi4Uzv4+frajahWq9Xo/WQPN1VFVHTkOzSOHTsWXbt2xeOPP46+ffvixIkTrqiLiIgoVzQaDf5YtQgNG9aDVqOBVqtF9epVsWLZAgQFBbq7PCKvl+/b023btsVHH30EjUaDrVu3Yvjw4di0aZMraiMiIsqVcuXKYs0fv+Hu3QRIkoSwsBLuLomoyMh3aOzQoUPG/zdo0AC3b9+GLMtZTrhKRERU0EJCgt1dAlGR49Ipd6ZPn46zZ89i+vTprjolEREREXkApz2NvXr1QlRUlMN9e/bsgUqVvgTU2rVrsXr1aixcuDBPhXCeRu+cz8lTsT1di+3pOmxL12J7uhbb03W8tS2zm6fRaWhcsWKF0wv89ddfmDJlCubOnYsSJfj8CBEREVFRk+9nGrdu3Yovv/wSc+bMQdmyZV1RExERERF5mHyHxg8//BAajQbDhg3L2DZ37lwEB/MhZCIiIqKiIt+hcd++fa6og4iIiIg8GOfFISIiIiKnGBqJiIiIyCmGRiIiIiJyiqGRiIiIiJxiaCQiIiIipxgaiYiIiMgphkYiIiIicoqhkYiIiIicYmgkIiIiIqcYGomIiIjIKYZGIiIiInKKoZGIiIiInGJoJCIiIiKnGBqJiIiIyCmGRiIiIiJyiqGRiIiIiJxSu7sAIiIiAhRFwa5d+7B6zXpotRo8/fQTqF+vjrvLIsrA0EhERORmiqLgreEfYu3aDUhLM0IURSxavBRvv/Uahr052N3lEQHg7WkiIiK327f/UEZgBABZlmE0mjB5ynTcuhXt5uqI0jE0EhERudmf6zfBaDTZbRdFFbZu2+mGiojsMTQSERG5mUGvhyja/5UsigL0er0bKiKyx9BIRETkZr17Pw6Nxn6YgSwreKRzBzdURGSPoZGIiMjNqlWtjDGffACdTgdfXx/4+fnCx2DAT7O+Q0CAv7vLIwLA0dNEREQe4aX+z6F7967Ytm0XtBoNOnVqC19fX3eXRZSBoZGIiMhDlAgNwVO9H3d3GUQO8fY0ERERETnF0EhERERETjE0EhEREZFTDI1ERERE5BRDIxERERE5xdBIRERERE4xNBIRERGRU5ynkYiIyEvJk74ADuz9d4NaDfw4F2JgoPuKoiKLPY1EREReSP51dubACAA2GzDwBfcUREUeQyMREZE3WrMyy13y1s2FVwcVGwyNRERERc2OLe6ugIoghkYiIqKiplUbd1dARRBDIxERkTfq3C3LXWLnroVYCBUXDI1EREReSBz8GlC/4X82isCMOe4piIo8TrlDRETkpcTR4wAAcloaRB8fN1dDRR17GomIiLwcAyMVBoZGIiIiInKKoZGIiIiInGJoJCIiIiKnGBqJiIiIyCmGRiIiIiJyiqGRiIiIiJxiaCQiIiIipxgaiYiIiMgphkYiIiIicoqhkYiIiIicYmgkIiIiIqcYGomIiIjIKYZGIiIiInKKoZGIiIiInGJoJCIiIiKnGBqJiIiIyCm1uwsgIiIiz5OWloa9ew9CpVahVctm0Gq17i6J3IyhkYiIiDJZvXo93hr+IdQqFRQoUIkq/PLLdLRq2czdpZEb8fY0ERERZbhx4yaGvT0SRqMRySkpSElJxb2kJLzYfwhSUlLcXR65EUMjERERZVi2fDUkSXK4b/2GLYVcDXkShkYiIiLKcO9eEqxWq912SZKQnJzshorIUzA0EhERUYZOHdvBx8fHbruiAO3atnZDReQpGBqJiIgoQ+vWzdGubatMwdHHx4AXX+yLSpUi3VcYuR1HTxMREVEGQRDw809Tse7Pv7B8xWpoNVr07fskexmJoZGIiIgyE0UR3R/rgu6PdXF3KeRB8h0aZ8yYgXXr1kGlUkFRFLz66qt49NFHXVEbEREREXmIfIfGF154AUOHDgUAxMTEoFu3bmjdujUCAwPzXRwREREReYZ8D4Tx9/fP+P+0tDQIggBZlvN7WiIiIiLyIIKiKEp+T7J48WL8+uuvuH37Nr744gveniYiIiIqYpyGxl69eiEqKsrhvj179kClUmX8fO7cOYwYMQLz5s1DcHBwrgqJj0+BLOc7v3qtsDB/xMZy0lRXYXu6FtvTddiWrsX2dC22p+t4a1uKooDQUD+H+5w+07hixYocX6h69eooWbIkDhw4gC5dOOKKiIiIqKjI9zONFy9ezPj/Gzdu4MyZM6hSpUp+T0tEREREHiTfo6enTZuGixcvQq1WQ6VSYfTo0ahcubIraiMiIiIiD5Hv0Pjdd9+5og4iIiIi8mBce5qIiIiInGJoJCIiIiKnGBqJiIiIyCmGRiIiIqJCkpaWhh9mzEbXbk/hqaf7Y83aDXDBOiuFIt8DYYiIiIjIObPZgu6P98WVK9dhMpkAAEePHceBg0cw7tMP3Vydc+xpJCIiIioEq1atxbVrNzICIwCkpRkxb95vuHUr2o2V5QxDIxEREVEh2LxlB9LSjHbbNRo1Dhw87IaKcoehkYiIiKgQlCpVEmq14ycDS4SGFnI1ucfQSERERFQI+r3QBxpN5tAoCAL8/f3QqlUzN1WVcwyNRERERIWgSpVKmD5tEgIC/OHn5wuDwYDKlSKx9H+/QqVSZTr26tXreLH/EERWqo8atZph7LiJMJnMbqo8HUdPExERERWSR7t1RueH2+PUqbMw+BhQrWplCIKQ6Zj4uwno9tjTSEpKhizLMJvNmDN3Ec6eu4DFC392U+UMjURERESFSqPRoEGDulnunz//N5hMJsiynLHNbDZj//5DOHfuAqpXr1oYZdrh7WkiIiIiD/L38VMOb0WrVCqcO3fRDRWlY2gkIiIi8iC1alaHVqu12y5LMipViiz8gv7B0EhERETkQV7s1wc6XebQqNVqUaduLdSpU9NNVTE0EhEREXmU8PCSWLViIZo2aQhRFKHVatGrV3csnD/TrXVxIAwRERGRh6lZszr+WLUYNpsNoihCFN3fz8fQSEREROShslpBxh3cH1uJiIiIyOMxNBIRERGRUwyNREREROQUQyMREREROcXQSEREREROMTQSERERkVMMjURERETkFEMjERERETnF0EhERERETjE0EhEREZFTDI1ERERE5BRDIxERERE5xdBIRERERE6p3V3AfaIouLsEt2MbuBbb07XYnq7DtnQttqdrsT1dxxvbMruaBUVRlEKshYiIiIi8EG9PExEREZFTDI1ERERE5BRDIxERERE5xdBIRERERE4xNBIRERGRUwyNREREROQUQyMREREROcXQSEREREROMTQSERERkVMMjURERETklMesPV3cjB07Fnv37oVWq4WPjw9GjRqFunXr2h23fPlyfPHFFyhTpgwAoGzZsvj+++8Lu1yPdOXKFYwcORKJiYkICgrCxIkTERkZmekYSZIwfvx47Ny5E4IgYPDgwXj66afdU7AHS0hIwPvvv4/r169Dq9WiQoUKGDduHEJCQjIdN3LkSOzZswfBwcEAgK5du2Lo0KHuKNmjdezYEVqtFjqdDgAwYsQItGnTJtMxRqMRH374IU6dOgWVSoUPPvgAHTp0cEe5Hu3mzZt4/fXXM35OTk5GSkoKDhw4kOm4adOmYdGiRShZsiQAoFGjRhgzZkyh1uqpJk6ciA0bNuDWrVtYvXo1qlWrBiBn36EAv0cf5Kgtc/r9CRSB71CF3GLLli2KxWLJ+P9OnTo5PG7ZsmXKm2++WZileY1+/fopK1euVBRFUVauXKn069fP7pgVK1YoL7/8siJJkhIfH6+0adNGuXHjRmGX6vESEhKUffv2Zfw8YcIE5cMPP7Q77oMPPlDmz59fmKV5pQ4dOijnzp3L9php06Ypo0aNUhRFUa5cuaK0atVKSUlJKYzyvNr48eOVsWPH2m2fOnWqMmHCBDdU5PkOHjyoREVF2X0uc/Idqij8Hn2Qo7bM6fenonj/dyhvT7tJhw4doNFoAAANGjTA7du3Icuym6vyHvHx8Th9+jS6d+8OAOjevTtOnz6Nu3fvZjpu3bp1ePrppyGKIkJCQvDwww9j/fr17ijZowUFBaF58+YZPzdo0ABRUVFurKjo+/PPP9GnTx8AQGRkJOrUqYMdO3a4uSrPZrFYsHr1avTu3dvdpXiVJk2aICIiItO2nH6HAvwefZCjtixO358MjR5g4cKFaN++PUTR8R/HgQMH0LNnTzz//PPYtm1b4RbnoaKjoxEeHg6VSgUAUKlUKFmyJKKjo+2OK126dMbPERERuH37dqHW6m1kWcbixYvRsWNHh/vnzJmDHj164LXXXsOlS5cKuTrvMWLECPTo0QOffvopkpKS7PZHRUVlPHYC8LOZE1u2bEF4eDhq167tcP/atWvRo0cPvPzyyzh69GghV+ddcvodev9Yfo/mjLPvT8C7v0P5TGMB6dWrV5b/0tizZ0/GL+ratWuxevVqLFy40OGx7du3x6OPPgq9Xo/Tp09j0KBBmDdvHipXrlxgtVPx9tlnn8HHxwcvvPCC3b7hw4cjLCwMoihi5cqVGDhwIDZt2pTxeaZ0CxcuREREBCwWCz7//HOMGzcOX3/9tbvL8nrLli3Lspexb9++GDJkCDQaDXbv3o3XXnsN69aty3h2jKgwZPf9CXj/dyh7GgvIihUrsH//fof/3f9w/PXXX5gyZQpmz56NEiVKODxPSEgI9Ho9AKBWrVpo1KgRjh8/Xmjvw1NFREQgJiYGkiQBSH9Q+86dO3a3DSIiIjKF9+joaJQqVapQa/UmEydOxLVr1/Dtt9867PkODw/P2P7EE08gLS2NPQ4O3P8carVaPPfcczhy5IjdMaVLl8atW7cyfuZnM3sxMTE4ePAgevTo4XB/WFhYxiM/rVu3RkREBC5cuFCYJXqVnH6H3j+W36POOfv+BLz/O5Sh0U22bt2KL7/8ErNnz0bZsmWzPC4mJibj/2/duoVjx46hevXqhVGiRwsNDUXNmjWxZs0aAMCaNWtQs2ZNu9FqXbt2xZIlSyDLMu7evYtNmzahS5cu7ijZ402ePBknT57E999/D61W6/CYBz+PO3fuhCiKCA8PL6wSvUJaWhqSk5MBAIqiYN26dahZs6bdcV27dsXvv/8OALh69SpOnDhhN8Ka/rVixQq0a9cuy57DBz+bZ86cwa1bt1CxYsXCKs/r5PQ7FOD3aE7k5PsT8P7vUEFRFMXdRRRHLVq0gEajyfQLOnfuXAQHB2PUqFHo2LEjOnXqhMmTJ2Pz5s0ZvZMDBgxAr1693FW2R7l06RJGjhyJpKQkBAQEYOLEiahUqRIGDRqEYcOGoW7dupAkCePGjcPu3bsBAIMGDcoYfED/unDhArp3747IyMiMnu370zv17NkTs2bNQnh4OF566SXEx8dDEAT4+fnh/fffR4MGDdxbvIe5ceMG3nzzTUiSBFmWUblyZYwePRolS5bM1JZpaWkYOXIkzpw5A1EU8d577+Hhhx92d/keq0uXLhg1ahTatm2bse3B3/UPPvgAp06dgiiK0Gg0GDZsGNq1a+fGij3H+PHjsXHjRsTFxSE4OBhBQUFYu3Ztlt+hAPg9mgVHbfntt99m+f0JoEh9hzI0EhEREZFTvD1NRERERE4xNBIRERGRUwyNREREROQUQyMREREROcXQSEREREROMTQSERERkVMMjURERETk1P8BH11byycDGDwAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAo0AAAHUCAYAAABfxBLvAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/d3fzzAAAACXBIWXMAAAsTAAALEwEAmpwYAABqRElEQVR4nO3dd3gU1RoG8He2b3ohCaGGTuhNEJCOFAEpinBVFEEULFiQoqIgoohUQcCGSkc6UpUuvffeWwKEFNK2z9w/AitxN9lNssnuJu/vee5zyczszLeHzfJ6Zs45giRJEoiIiIiIsiFzdwFERERE5PkYGomIiIjIIYZGIiIiInKIoZGIiIiIHGJoJCIiIiKHGBqJiIiIyCGFuwt4JDExDaJYdGf/CQ31Q3x8qrvLKDTYnq7F9nQdtqVrsT1di+3pOt7aljKZgOBgX7v7PCY0iqJUpEMjgCL//l2N7elabE/XYVu6FtvTtdierlPY2pK3p4mIiIjIIYZGIiIiInKIoZGIiIiIHGJoJCIiIiKHGBqJiIiIyCGGRiIiIiJyiKGRiIiIiBxiaCQiIiIihxgaiYiIiMghhkYiIiIicoihkYiIiIgcYmgkIiIiIocYGomIiIjIIYW7CyAqLEwpOiQeuwyFnwbBtctDkPG/yYiIqPBgaCRygetL/8G5icsgU8ohSYDCR40nZr0L/4ol3V0aERGRS7ArhCiPkk5dw7lJyyAaTDCn6mFJ08MQ9wAHBk6DZBHdXR4REZFLuKSnMTExEcOGDcONGzegUqlQtmxZjBkzBiEhIa44PZFHu7l8J0Sj2Wa7Jd2AhCMXEfpEFTdURURE5Fou6WkUBAGvv/46/vrrL6xZswalS5fGxIkTXXFqIo9nTEwFRMlmuyAIMKfo3FARERGR67kkNAYFBaFRo0bWn+vUqYOYmBhXnJrI40W0rgO5VmWzXTSZEVy3ohsqIiIicj2XP9MoiiIWLVqE1q1bu/rURB6pRMcn4FexxL/BUQDkGhUqvdUFqmA/9xZHRETkIoIkSbb31fLgiy++wN27d/H9999DxilHqIiwGEy4umoPrv25H+ogX1R+tS0iGvJZRiIiKjxcGhrHjx+P8+fP44cffoBKZXu7Ljvx8akQ7TwXVlSEhfkjLi7F3WUUGmxP12J7ug7b0rXYnq7F9nQdb21LmUxAaKj9u2Qum6dx8uTJOHXqFH766accB0YiIiIi8mwuCY0XL17Ejz/+iKioKPTu3RsAUKpUKcyYMcMVpyciIiIiN3NJaKxUqRLOnz/vilMRERERkQfiSBWiPEq7dw9bO3yCf54f4+5SiIiI8g3XnibKg41PvAPJZAEAGABsqDMIPuUi0GLlaLfWRURE5GrsaSTKpb1vTrEGxselX72LeyevuqEiIiKi/MPQSJRLSfsvZLnv8KsTCrASIiKi/MfQSJQfivCco0REVDgxNBLlA02pYu4ugYiIyKUYGolyqf4v72e5r9XaLwuuECIiogLA0EiUS+ENqiB6ZG+b7c3//sIN1RAREeUvTrlDlAdRz7dA1PMt3F0GERFRvmNPIxERERE5xNBIRERERA4xNBIRERGRQwyNREREROQQQyMREREROcTQSEREREQOMTQSERERkUMMjURERETkEEMjERERETnE0EhEREREDjE0EhEREZFDDI1ERERE5BBDIxERERE5xNBIRERERA4xNBIRERGRQwyNREREROSQwt0FEHmT6yt24syYhZm2Rb36NKI/6OGmioiIiAoGexqJnGRITrYJjABwbc4m3D9y0Q0VERERFRyGRiIn7Xru6yz3HRo0vQArISIiKngMjUROMiYkZ7lPMpgKsBIiIqKCx9BI5CRloF+W+wQVHw8mIqLCjaGRyEnN/hiZ5b56UwcWYCVEREQFj6GRyEnqsABU+ch2lHSpnk8hvEl1N1RERERUcHhPjSgHyr/8NMq//DQMBgMAQK1Wu7kiIiKigsHQSJQLDItERFTU8PY0ERERETnE0EhEREREDjE0EhEREZFDDI1ERERE5BBDIxERERE5xNBIRERERA5xyh0iJ+jvJuHujuMQZDKEt6gFTVigu0siIiIqUAyNRA5c/2MHzk1aDggABAFnJyxF9Y97o1S3Ju4ujYiIqMDw9jRRNtJvxeHc5OUQjSaIBhNEvRGiwYTT4xZDdzfR3eUREREVGIZGomzc2XQUkija3Xd3y9ECroaIiMh9GBqJsiFZLIAo2e4QJUgW+2GSiIioMGJoJMpGeKs6EBRy2x0yAeEtahV8QURERG7C0EiUDf8KkSj36tOQaZSATADkMsjUSlQY8Ax8y4S7uzwiIqICw9HTRA5UfqsLiretizubjgCCgMh29eBfsaS7yyIiIipQDI1ETgioXAoBlUu5uwwiIiK34e1pIiIiInKoSPU0nr9wCdu2/gNfP190eqYdQkKC3V0SERERkVcoEqFRkiR89vnXWLBwKUTRArlcgVGjx+GXn6ejdatm7i6PiIiIyOMVidvTO3fuxaJFy6DX62E0mqDT6aDT6fHGm+8hXadzd3lEREREHq9IhMYly1bZDYcyQYbdu/a5oSIiIiIi71IkQqNosdjdLgGwZLFEHBERERH9q0iExh7du8DHR2uz3WIxo9lTT7qhIiIiIiLvUiRCY5s2LdCpU3totVoIggCVSgWNRo3p342Hr6+vu8sjIiIi8nhFYvS0IAj4bso4vPbqi9i8ZTv8/HzRrWtnREZGuLs0IiIiIq9QJEIjkBEc69athbp1a7m7FCIiIiKvUyRuTxMRERFR3jA0EhEREZFDDI1ERERE5BBDIxERERE5xNBIRERERA4xNBIRERGRQwyNREREROSQy0Lj+PHj0bp1a1SpUgUXLlxw1WmJiIiIyAO4LDS2adMGCxYsQMmSJV11SiIiIiLyEC5bEaZBgwauOhUREREReRg+00hEREREDnnM2tOhoX7uLsHtwsL83V1CocL2dC22p+uwLV2L7elabE/XKWxt6TGhMT4+FaIoubsMtwkL80dcXIq7yyg02J6uxfZ0Hbala7E9XYvt6Tre2pYymZBlRx5vTxMRERGRQy4LjWPHjkXz5s1x584dvPbaa+jUqZOrTk1EREREbuay29MjR47EyJEjXXU6IiIiIvIgvD1NRERERA4xNBIRERGRQwyNREREROQQQyMREREROcTQSEREREQOMTQSERERkUMMjURERETkEEMjERERETnE0EhEREREDjE0FhF6vQH7DxzG6dPnIEmSu8shIiIiL+OyZQTJc61YsQbDRoyCTCaDxWJBREQ45s/9EeXLR7m7NCIiIvIS7Gks5M6cOY8hQz9DWlo6UlJSkZ6uw7VrN9CzV1+Iouju8oiIiMhLMDQWcnPmLoLJZMy0TZIkPHiQgn37D7mpKs8liiLDNBERkR28PV3I3Yu7D4vFNgQJApCYmFTwBXmoW5duYPI73yApLhEAEBgahA+mDUeZqlHuLYyIiMhDsKexkHu6bUv4+GhttptMJjzRoK4bKvI8ep0eo1/82BoYAeBBfBLG9PkU+nS9GysjIiLyHAyNhVyP7l0QVbYMtFqNdZuPjxaDBvZHeHiYGyvzHGt+WgHRTm+sKIpYMfMPN1RERETkeXh7upDTaNRYs2YxFixYgj/XbEBgQCBe6/si2rRp4e7SPMb189ey3Hfj/PWCK4SIiMiDMTQWAT5aLQa8/ioGvP6qW64vSRK2LtmEjfPWIDUpBeVrVkKvD15Gmcpl3VLPf0VFl8OZ/Sft76taroCrISIi8ky8PU35btn3i7F02kLEx96HQWfA2QOnMK7fKMReve3u0gAAzw54DnKF3Ga7TC5Dt0E93VARERGR52FopEzuXI/Fgglz8N373+Kv+eugS03P0/l0qenYvGgDjHpDpu0mgwl//rwCR3ccwoG/9yIlMTlP18kLlUaFLxaPR2hkMeu24IgQjF44DhofTTavJCIiKjp4e5qsTu87gelDJsFsskC0WHD24GlsWrgBny/4GgHBAbk6Z9zte5ArFDAZTJm2i6KIA3/vxfFdRwFJgsVswQvvv4Q2vdq74q3kWIlyJTFh7XS3XJuIiMgbsKeRAGSEuNmjf4BRb4RosQAAjHojHsQ/wLpfV+X6vCERoTCbTHb3SZIEfZoO+nQ9TEYTlny3EDcvcuAJERGRJ2JoJADA/Zg4pKek2Wy3mM04su1grs/rF+SPhk83hlKtcnis2WTGrj932N2XnJiMbUs3YcOcPxksiYiI3IC3pwkAoPHRZLl8ntbXdnLwnOj72Rvw8ffFP6u2wmwywzfAD/o0HUzGzD2QkihCl6azef2JXUcx/aNJEC0iJFHCiplL0KxbK/QZ0Q+CIOSpNiIiInIOQyMBAAJCAlGhZiVcPHbBensaAFQaNdr07pDl67av2ILl3y9Geko6/AJ98cJ7L6Fpl8xzQCqUCrw49FX0+uBlmIwm6NN0GPbsezbnUmvVaNC6ofXn80fO4p8VW7F3w65Mx1nMFmxfthnbl222bvv18KIcv2ciIiJyHm9Pk9XArwcjMioSaq0aGl8tlColGndsimZdW9o9fv2cPzH3q1+Q9iAVkigiJTEFs0f/gE0LN9g9Xq6QQ+OjQVBYMLoPfB4qjcraU6jWqhHdsAZqNKkNs8mMsa9+hvEDxtgExqz0q/8/GHXGXL1vIiIicow9jWQVWCwIY/74FldPX0bivURERZfLNA3Nf62ctdTu9mXfL8bTL3bM8nWiKKJM1XJ4qksLxF6PRUBwABq2b4zazepBJpNh7exVuHLqUo7rH/jUqwgKC8Y3K6dat1ke9prK5bbzMBIREZHzGBopE0EQUL5GRYfHiaIIi8lsd5/JkHWPn0FnwISBY3H78i2YjEao1CqoNGp0H/QCZLKMju+tS//OXfEAkuISMfCpjJVvFColzA+fm1SqlPhg+nBUbVA91+cmIiIqyhgaKVceBTx7shucsvbXlbhx4bo1zOnT9TDoDPhp5PcYOedLABnPLLqC+bGBNiajCd++OdbucRp/LVp2b4uubzwHtVbtkmsTEREVNnymkXKtWsMadrfXblY3y9fsWbszU5gDMuZrvH7+GlIfpAIAGrZr7LoinaBP0WHj3DUY++pISJJUoNcmIiLyFgyNlGvvTx+OctXKZ9pWsXZlvDNpSJavySqUWUxmvNf2DSwY/xt6vPUCAkMDXVqrM25fvoUlUxcU+HWJiIi8AW9PU64pFAp8Nu8rJCc8wM0L11GmShT8HSw32KhDU2z5YyPMRtvnISVRwpYlf0OXpsO3a6Zh69JN2LdxN+QKBa6fuwKLyTW3rbPz94L1eO6d3lAo+atBRET0OPY0Up4FhASi+pO1HAZGAHh2QA8UL1sCah9NlsfsWbcTSrUK7V/uhFHzv8bI38fg7W8/hEqTMRVQdq/NK0mScOX05Xw7PxERkbdiaKQCpfXVYtT8r/HG2LezPe7d1gOwYMIc69KGdZrXw9RNP6D/6EHoP3pgvtbIRWaIiIhsMTRSgZMr5KjbokG2x6Q9SMWO5Zvx1WujYH44tY/GR4P6rZ9AgzaN8Nzg/+Vbfb4Bfvl2biIiIm/F0EhuYdDpIciy79Izm8y4cy0GI559D5sXbcg0/2NwaFC+1Xbp+IV8OzcREZG34tP+lCdJcYnYMHcNzhw4hZDwUHR8tQuqNqjm8HX7Nu5xanobSZKQcC8BCyfOxfYVWzF64TicO3gav4ya5Yry7XIUZomIiIoihkbKtcR7CRj1vxHQpabDYrbg9qWbOH/kDJp1b40ylcri9P6TOLXnGFRqNVo81wadXutqHZV88dg5IIdTIsZcvYX9f+3B0u8W5sO7+VdaUgrMJjN2rNiCf1Ztg2gR0aRzM7Tt1R5KtSpfr01EROSpGBop19bOXmUNjI8Y9UZsWbQx03HpKelY//ufuHHuKt6d/BEAQJeqy/kFJWDv+p1ISUzOU92OLPluIXb+uR3xsfdh1GfcEl/1wzIc2XYQH/8yGjI5n+ogIqKih//6Ua6d3n/C6SX/TAYjTu07idirtwEgy3WrHVFpNZBy2kWZC7FXY6yBEcio/9bFmzi551i+X5uIiMgTMTRSrgUWC8rR8XKFHDcv3gAAaP19cnXNhNi4HN/WdhWDTo8LR8+55+JERERuxtBIudbxlS5QadROHy+JIsJKhsNkMKJao5o5fj6weY/WiL0Wk9MyXUalViEkItRt1yciInInhkbKtTrN66P7oJ5QaVRQqpQOj/cJ8MWJ3ccwuM0bWDhhDixmMwSZAIVK4dSyfWElwlxRdq7J5DI0at/ErTUQERG5iyA5M+9JAYiPT4UoekQpbhEW5o+4uBR3l5ErBp0ety7dxJTB45GenJblcTK5DJIkQXrs71mpUqJi7cpo0rk5KtaujM97Dc80H6NHEAT4Bvii+pO1UK1hDTRq3xhqbf4tZeiJvPnz6WnYlq7F9nQttqfreGtbymQCQkPtL3LBnkbKM7VWgwo1K2Hi+u/xRLsnoVSrIMht5zoULWKmwAgAJqMJl09ewpMdmiKidHG39ybaJUkw6g048NceLJo4B8O6DMbGeWtx5eQld1dGRERUYDjlDrmMRqvBoHHvAQAGPdUXBp3BqdcZjUZ8M34KOnRoiwq1KyPm4QhrT2IymAAABp0BBp0BS6YuAAD4Bvph9IJxCI0sBiBjMvJHz11GRpWAwIWsiYiokGBoJJc7sGmv04ERAHQmA2bMmo1ff1uAzm3bQqFUWNeb9nRpD1IxtPO7UGvVqFK/Gm5euI60h7fo/YP98faEDxAVXd7NVRIREeUdb0+Tyx3bcSTb/Y/3vplFC84k34IkSUjX6bB2y2ZUaVErv0t0OYPOgBO7jiLxXgKMegOMegPiY+9jwptjoUtNd3d5REREecbQSC4XUToiy30lK5ZG3RYNoA30RaI5DYcTr+Ce4YF1fx1NGZzadLggyiwQoiji4Ob97i6DiIgozxgayeU6vvosZDL7H603v3oH70z6EB2H9MQp/W0kmFKt+4op/RGg1Baq5wCNeiMe3E/MtM2gM0C0iG6qiIiIKHcYGsnlVBoVhv30GdTafyf+lsll6DtyAEpVLAMAaNXyKVj+E5yqBZQq0DoLgkqjQuW6VQEAp/aewIhu7+Pt5v3wVvPXsHjyPK95dpOIiIgDYShfVK5bFbN2/Y6bF65Dr9OjQs1KmXoffX198eOsyXhz0AcABFgslix7J72VSqNChVqVUbleNK6evozvP5pkXc/aqDdi+7LNSE9OQ7/RA91cKRERkWMMjZSvSlcum+W+p59uhUMHtmHDxs1IT9dBlWTGjkWbCrC6/CMIAmo3q4cBX74NQRCwdvYqGP8zabnRYMT+v/bghfdfgl+Qv5sqJSIicg5DIzlt7a+rsHLWEusE3cHhIRizZDx8/e3PHO+MkJBgvPRiT5gMRuxZvws7XFWsm0mShJN7jlv/fOHYOcDOgkdypQIJd+MzhUbRIuLU3uO4cyMWJcuXQnTDGoWuF5aIiLwPQyM5Zc+6nVgx449M2xLvJWBIh7cx7MfPEBwRguCwkFydOzEuAaP/9zFSEpNdUarHEEUR927dxc0L15GeYn/aHYvZjLCS4dafkxMeYFz/0XhwPwlmkxlypQJhJcMx4udR8PH3KajSiYiIbLD7gpyycMIcu9uNeiO+feNLjHj2fUz7cCIMOn2OzmuxWDB+wJhCFxgBwKgzYM+6nfjz5+WQRPujpZt3aw2t379hcN43v+L+7Tjo0/Uwm8wwpOtx51oMlnw3v6DKJiIisouhkbIkSRIuHD2HLUv+RnpqWpbHGQ1GmIwmnN57AnO+mu30+XWpOgxs8iru3bzrinI90sa5axB7NcbuPplChrb/62D9WRRFHN1+GBaLJdNxZpMZB/7am691EhEROcLb02SXQafHxLe+xq2LNzLmFLTzPN5/mYwmHNqyH69+2h9qrcbh8VMGfwOL2eLwOG+W3XyMkigh9moMIkoXf7ghI6jn9DxEREQFgT2NZNeqH5fhxrlrMOgMMBlNTr9OQEYPojMun7yYy+oKB0mU8MOI73DmwCkAGXNZVmtYHYIs8+TmMrkMdVrUd0eJREREVgyNZNeetf/kKCw+4hvoh8BiQa4vqJAyGoyZBhi9+ukA+AcFWHtq1VoNgooF439DXgGQcQs75uptxMfed0u9RERUdPH2NNllMWdzO1SA7e1qAVCpVegzop/TywCWq1YeV05dznWNhUXMlVvWPxcrEYbxf07Fgb/34vblWyhTJQpPtG0EpVqF0/tP4ufPZsCQrocoiihRriTenvAhipUIc2P1RERUVLCnkeyq16oB5Aq5zXZBJth9vjG8ZASG/fgZ6rZs4PQ13pk0JCOAFnEGnQFfvjISackZ63CrtRo069oKvT/sgyadmkGpViHu9j1M/3AikuMfZDwyYDDhxoXrGP/GGIhZjMwmIiJyJYZGsuv5wS8iKCzYeptUpVFBpVVDpVbZPT6yfEmUr1HR6fOv+301hnR8x6kBNoWdJEm4eeE65nz1S5bH7Fi+xab3VxIlpD1IxflDZzJtFy0izh44hf1/7eFtbCIichnenia7AoID8NWySTi4aS+unb2K4mUjUaVeNL58ZaTNsSqNCtENqmd7Pr1Oj9WzluH80bNQadS4cORsfpXulcwmM45uPwyTwQilnWB+/859WMxmm+0SgKT7Sdaf7968g2/f/BK6h5OJm80WtHquLXoP6eP0YwNERET2MDRSllQaFZp2aYGmXVpYtzV+5ins27gHRr0BACBXyOEX6I9mXVtmeZ742Pv4uPsHMJtsQ483U2nVCA4LQeLdeBgNRihUSkiiCJlcBplcDtFigcng/GAi0WKB2WS2GxqrNayB4zsOw/Cw3a2vMVtQoWYlABk9ltPen4Cke4mZpu75Z9VWVKpTBQ3aNsrlOyUiImJopBx65dPXEVWtPLb88Rd0aTrUa/UEOvfvnmlVk/+a/tGkQhcYAUASRQwa/x7Sk9Nwcu9xXD97BZeOXwCQEQDrtmyAw1sPwuLke5ckCakPUm3aUpIkhBYPhVKjsgmNoZHFUKxkxkCY2GsxiL8TbzPXo0FnwJYlfzE0EhFRnrgsNF69ehUjRoxAUlISgoKCMH78eERFRbnq9FQADvy9F+t+X43k+w9QqW4VdB/0AiKjSmQ6RiaToeVzbdHyubZOn/fmheuuLtUjaP18UKZyWQDAtbNXcOn4RRj1Ruv+YzsO5/iW8PCu76FEuZJo+VxbBBULRunKZfDrFz/ixvlrmc79SPyd+9i0cAPav9wJBp0eMrn9x5T1ac7NnUlERJQVl4XGUaNG4cUXX0TXrl2xevVqfP7555g7d66rTk/5bMPcNVj943LrbefDWw7g1N7jGL3gG4SXjsjj2e3N0eP90h8+NwgA63//09p2jxj1xpyPDpeAmCu3sXDCHKi0apgMJghAliOkTQYTNi/eiPYvd0LpSmUhk9leUKlWoWG7JjkshIiIKDOXjJ6Oj4/HmTNn0LlzZwBA586dcebMGSQkJLji9JTPjHoj/vxpeabQI0kSDDoj/vxlRZ7PX7FWpTyfwxOZjSZ83msYdq3ZgdQHKfYPykNWNuoMkETR4ZQ6j8KrQqlAv1EDodKoIJNnTJek1qoRXioCrV94GvGx97Hku4WYMng81vyyAimJybkvjoiIihyX9DTGxsYiIiIC8of/UMnlcoSHhyM2NhYhISFOnSM01M8VpXi1sDB/t1z3+vlrkMls//tBEkVcPXnRYV2JcYlY/sNyHN1xBMHhwejxZg/Ue2zZu9FzR+H1Jv2dXl7Qm9y6dBPzv/kVWl+t3fcXHB6M9JR0GHT/BnKFSoEqdaog4W4C7t26B4slb+tv136qtvXvqP0LrVG9fmVsmL8B8Xfi0aBVfTR/tgWunb+Gz3p/ArPRDLPJjPOHz2Dz4o2YsnYqIpzsSXbX57MwYlu6FtvTtdierlPY2tJjBsLEx6dCFAvfLUxnhYX5Iy4ui96qfCbKVDBlMVgjKCI027oexCdhVO/hSEtJh8Vkxo0LN3D20Dk8/05vtP1fh4dHCZi+7RdsnLcWy6Ytyod34F72njUEAAgC+n72Jg5t3oe9G3ZDJhNgNpqhVKkQe+MOkuISERASiJTEZFjMuQuOMrkMXd/siVNHLuLYjsOQyWSo37ohur3V23rMgxQDpnw4Ffo0faaaTUYTZn3+I97+9gOH13Hn57OwYVu6FtvTtdieruOtbSmTCVl25LkkNEZGRuLu3buwWCyQy+WwWCy4d+8eIiMjXXF6ymd+Qf6o27I+ju04nGmKGJVGhc79umX72o3z1iEtOT3THIJGvQHLZyxGs26toNaqAWQMoClXrQJkchlES9FYwUSpVMAv0A99P3sDyQkPcHr/SYiiCF1qOnSpGbeUk+ISIZPLIFcqnB5l/YhMLsOLQ/vi8JYDWP3zckiiBAgCln2/CJ37dUPpylGILFcCQcWCEXP5ls3rJVHC6X0nXPJeiYio8HNJaAwNDUV0dDTWrl2Lrl27Yu3atYiOjnb61jS5X/9RgzDn619wcNM+yAQBKq0a//voFUQ/kf2k3af3nrA76bQgkyHmyi2Uq17Bus0vyA8KpRJGi8HmeE8iCAJqNqmN0/tP5roHEADkSgUS7iZAn6bDuUNnYDbaD4WiRYRKpYRfgC9SH6RmhGohI9SpNGoEhQXhiacbY+PcNRAEAZIkQa6Qo36bRqhctwq+fOUzm/kgV85aCo2PBhaLBdENakCQyQA7z0aqNZpcvz8iIipaXHZ7evTo0RgxYgRmzpyJgIAAjB8/3lWnpgKg0qgwYMxb6DOiH9KT0xAUFpzl9C2PCwoPxq1LN2y2W8xm+IcEZNpWqmIZhEYWw51rMTZzCf5XcHgIHtxPKvB1lZt1bYl2L3fCxWPnce7IWdvQmIOB4BaTGeWqlcfG+WszPdNoj9lowjebfoRaq0bs1dvYunQT4u/cR83GtdGkczOotRo80/dZHNl6AKkPUhH9RHWUqRKF1T8ttxvaAUCfnnE7+uyhUwgrGYb7MXGZ5stUqlVo+bzzUycREVHR5rLQWKFCBSxdutRVpyM30fhooPFxvvepQ5/OuHDkbKbn+uQKOcrXqIhikWHWbfp0PRZPmou423cdBkYASLyXgCefeQr71u9yeKxSpYTJ6PzKK1lRqVV47fM3AQCBoUFYPGmezTECBAgywWGYFWQCmnRujpDiodD4aCFXyLPttdT6+kClyVgJJrJcSbw0rK+dY7SZVucBMgYrOWIymJBwLwHlqlfA9XNXIZPLYTGbUeupOuj0WleHryciIgI8aCAMeadqDWug1wd9sGTqAggyARazGRVqVsIbY9/Bzj+348Bfe6BUq3Dv5h3cu3Uvy1u0NgTgyNYDTh2a19HH9vgF+uGdiR9i5rApMJstMD8MpZIkQRAygqOUzcCtoGLB6Pnei9i+Ygvux9zL9lpKtQpdBvTI1drQDdo+iY1z18JoyWIwzkNGnQG9h/SBQqnAvZv3UKpSaUSULp7j6xERUdElSM50+xQAjp72zlFWj5gMRsRcuQ3/4AAEFgvChEFf4dqZy1mPLHZAkAuAhGyDmav5BfmjTJUo3I+NQ1JcIkLCQ1C/TUNs+H2NTc+iUqVEpbpVcGb/KdsTCUCd5vVx5eQl6HV6GHUGyBWKLG8jhxQPxdhlE6HRZt/Dm5acins37yI0shgCQgIBZEz6Pa7/F7h84oLD9+fj74sXh/VFo3aNIVfIHR7/OG//fHoStqVrsT1di+3pOt7altmNnmZo9BDe+uGy59CW/Zg9apbD5/g8Tg4XrmnQthF0qTqcOXDSJtz6hwQiNTHZqVvxSrUSnft3R5f+3e3uF0URf0xZgG3LNkGpVMBkMqNB64Z4bdSb2Dh3Ldb9tipH4Vwml+PFoa8g8V4iHtxPRI3GtVGv1RNQKLO+8VCYPp/uxrZ0Lbana7E9Xcdb2zLfp9whAoAzB05h8aS5uHXpZp7PpVQpYTFbCnYgTA4CoyAT4Bfoh9e/eAuLJs3FzlXbMtWakvDA6XOZDCbsXbczy9C4ctZSbPljI0SLaL1NfnjbQfgG+mHvhl057s0VLRbM/+Y36/RHBzftw8Z5azHi51HW5yqJiIj+i6GRcuRBfBJ2rt6OO9diULF2ZTR+5imotRpcOn4B0z6YkOvb0f9lNpuhUCggGj1zTkeFQoEW3dtApVGh6xvPYdeaHXantHFWVreLb1++iXW/rrLZbjIY8c/KrXkaAPRovkyDzoCYy7cw56ufkZaSBqVSiWbdWqFmk9q5es6SiIgKJ4ZGctr1c1cx/o0xsJgtMBlMOLT1ANb+ugqfz/sKK2ctcVlgBDKeZczTiOgc3mrOKdEi4sj2gygbXQ43zl+DSq2ELoeTcz+i0qjQrFsru/uWfrcwy9dZzBYULxuJO9djbfZpfDQQJQlGJx8RMBqM2Ldht/V2+qm9x9G8W2s80/dZbFq4AVdOXUBoZDja9+mMoGJBuHzyIvyCAlC+RgUGSyKiIoKhkZw2e9SszEvR6Qx4YDJjxcw/EHPFdsURtxEy1j/Py8TcjlgsFmyctw4N2zVGSPFisJjt9zLK5HJIkCBltQqOAFSpF43WPdvZ3X3x2PksawgtEYaXhr+G6R9O/DewCxlTBw2eOhQKhQKzRnyHxHsJTr2nx5+/NOgM2LZsE3at2QGTwQizyQyZ7AL2btgFQRCgVKsgiRICiwXio5mfoliJsGzOTEREhYHj2ZuJkDFyN/aabY+WxWzBkW2HEFmulBuqyoKEfA2Mj1jMFhzdcRilKpZGyYqlbW4xqzQq9P30dfQY2DPL3rgylaPw/rThWQ5CyW6C9ZeHv4bqjWpi6A8jUaNJbYREhKJW07oY/tPnqFq/GirWroyPZn4CeTYDXLJjNpmhS023TgguiiJEiwiL2QJ9mg4GnR5xt+9h6nvfOjXgh4iIvBtDIzlFrlAgq/u9SpUS3Qf1LHKDKASZAPnDUPfBtOGo1qgmFEoFlGolgsND8M7EIajbqgFqN6uHGk1q2wRDlUaF59/pnWWgvB8bB12qzu6+qg2qoWaT2pAkCWaTGQ2fbozBUz7Cm1+9g8NbD2JYl8H45LkhOLH7GCasmYZGHZrAL9gfSrVr/44kUcL9mDjEXL3t0vMSEZHn4e1pcorGR4OqDarj7MHTEB+bTFupVqFFjzaoVKcK3pk4BAsn/G73GbvCqn6bRgAyJgP/YNpwpKekQZ+mh39IAOaNm43pH06EXKmAxWRGaGQxxN+Jh0IhBwTghfdeQo0mtbM89/GdRyFTyO0OBoqKLo/khAf49s0vEX8nHpCkjN4+QYDFbIHlYe/gyllLcP7wWQye8lHGzzOXYM3slS5tA7lcBl1KukvPSUREnoehkZz2+phBGD9gDJLiEiE9DClV6kXjmb7PAgBqNK6Fr1dMhi5Nh91rdmD3mn9w8+J16yhdb5Ttyi+SBL9A/0ybfPx94ePvi4UT5+DAX3thMpqsA3oS7yWix6CeqNm0DsJLF4dSpcz22nKFHDKZ7c0AuVwOtY8Gv37xI+7euJPtrXij3ogzB07ixvlrKFMlCjWa1HJ5aBRFCWWrRrn0nERE5HkYGslpgaFBGLtsIs4fPov7sXEoWyUKZapE2RxnMZkfBsqqMJstuH3pRsEX6yLZrUijUCmxa812xN26i8snL6FkhdLo8EpnFC8TiX9WbIXRkHk0uVFvwNalm9DhlS5OXbteqyewaOJcm+0yhRx1WtTH2tkrnXp2U5KAK6cuoVSlMvjh4+lOXTs7j9bRzhgQo8TLI/q6/LY3ERF5HoZGyhGZTIboJ6pnuf/KqUsY/8YYmI0ZwTG7gRzeTjRbsHz6YohixuCQG+eu4eCmfXjr2/ezDHMpSc6vDhAQHID+owdi9uhZkMlkGb27ooSeg/+H8JLhTp9HLpchODwEV09fhi7V/m3k0lXK4ub5606dT3rYs1iqYhm07tUO5apVcLoWIiLyXgyN5DKSJGHS2+NgMvw7v6I335p2xGQyI2OB7IyfRVGEUW/AkqnzERQejPjY+zavKV+jYo6u0bBdY0Q/UR3Hdh6BaLagVrO6CA4LAQCUrFAKNxwEPUEmQOunRY3GtXHhyNksB934Bfih1fNtsG3ZFoc1iaIIpVqF/l8MytF7ISIi71Z4u4GowGXXk1XoCEJGL6qdu9d3rsWi9wcvZxpNLsgEqLVq9Hr/pRxfyj84AM2ebYkWPdpYAyMA9Bs1EBpfLZTqjGcjVVo1/IMDEFo8FEq1CgqVAmWrlsOIX0ZDrpCjfM1KdpdlVGnUaNiuMfp8/Dpm7f4dletFO6wp4U58jt8HERF5N/Y0ksvEFqFpVxRKBcQsbkHLlXLUbfkEhv4wEmt+XoE7N2JRrloFdBnQAyXKlXRZDWWqROGbVVPwz6ptiL0Wg4o1K6Fxp2ZQa9WIv3MfCoUCQWHB1uPVWjVe+fR1/P7lz7CYzRAtItRaNUpVKoMmnZtnHKNR48mOTXH11KUsV+QRZAIq1alid196SjqO/XMYBp0eNRrXRlgObqMTEZFnY2gklylVsYy7SygwZqMJEAQIgpBpYmulWommnZtDJpehQs1KeH/a8HytIyAkEJ37dbPZXizS/gotjTs+hTJVorBz5VY8SEhG3Rb1Ua/VE5nmkKxStyqQzdKAao0aXd983mb76X0n8P1HkwFBgGQRsViahw6vdEb3QS/k/I0REZHHYWgklylTNQqhJYohPsb2Wb5C6eG8iIJcljFQxSKiSv1q6P3hK+6uLFsly5dC7yFZ1xhZriQatW+Mg5v2wfBw7Wrh4e34ui0aoPtbL6B42chMr0lLTsPU9ydY54d85K/561Cjce0seyaJiMh7MDSSywiCgMGTh2JU7/ztXfMkkiRBEAGLxQy5UoGLx87j3OEzCA4PRrES4dD6at1dotPiY+9j6bSFOLnnOFRqFWo0qY3khGSYjSY8/UIb1H+6qd2pdUSLiHH9R9kERgAwGUzYvXYHQyMRUSHA0EguVbpSGWh8NNCn691dSoF5dHvaYjLDYjJj6uDx0PhqYTGb0aZXe/Qc/GKWo5adYTaZceXUJcjkMpSvXjFfpjFKfZCKMX0+QeqDNEiiCF1qOk7uOoaaTWvj7QkfIizMH3Fx9qcLOr7zCOJu3bO7T5IkpD5IxZTB43Hx2HlofDTo8EpntHvxGZe/ByIiyl8MjeTQnnU78duYH61zD/oE+GLU/K/tDnIwm8xFKjBmRZ+WsWb01iWbEBQWgnYvdszVeU7tOY4fPpkGUZQASYJKo8K7kz9ChZqVXFku/lmxBfp0PaTHRlcbDUac2H0Md2/EIizMP8vXntxzLMtBMwBwZOtB65/1aTosnjQPZw+cxruTh9hd8YYov1gsFty4cQv+Af4oFhri+AVElAm/sSlbV89cwS+fz8w0WXV6chqGP/ue3eMFQWAQeIxRb8DKWUvw6XNDMOzZwfhl1Mwse+X+KzEuAd8PnYz0lHTo03TQp+uRnJCMSW+Pc3kwv3TiYqb5NR+RKxS4eSH7FX0CQgIhV8hzdL3jO4/g9SdewhtP9sGGOWty9Fqi3Nj41xbUrtsMbdt1Q/0GLdGrdz8kJCS6uywir8J/3SlbP382I8t9QzsPtpnAWq6QIyQyNL/L8iqGdD1ir8Xg/u047Fm7E8O7vodvB47Fqb3HrQNN7Nm3YXdGD+N/SJKEI9sO2nlF7pUoXwpype2NB9EiIjA0EOvmrsOMYVOwbPpi3I+Jy3RM0y4tIJfnLDQ+YjaZsXTaQvy9cH2uXk/kjFOnzuKtt4cgPj4B6ek6GI1G7N13AH1eHeju0oi8CkMjZSv+PwEh077YOIzo9j7WzF5p3bZ0+iLcv531ayjDuYOnMfmdb/BOy/7YvGij3WNSk1Iypvb5D4vZjLQHqS6tp3XPpzNNuwNkzEVZPKoEfvpsBn776lcc3nIAf81fi5EvDMX5I2etx4WVDMeb496F1lcLja8206Tmzlo6bVGe3wNRVn76ZQ4M/1kL3mQy4+zZ87hw8bKbqiLyPgyNlC25KvseJIvZgpUzl+DI9oO4cf4atiy2H4DIPovZgj+mzscvo2bh6PZDmR4DqNaoJtRatc1rZEL263/nRkjxUAz8+l0UKxkOmVwGuUKBOs3ro1z18kiKS7L2iFrMFhh1Bvzy+axM81PWbdEA3235Ce9/NwwDvnwbKjujrLNjMZnx9WujcGLXURj1RiTciYfZzmhsoty4ceOm3dWQFAoF7sTedUNFRN6JA2EoW407PYVtf2x2eNz3QyYXQDWFk8VswZ61/+DI1gMILBaET379Av7BAajWsAYq1a2KC0fOwajPCG1qrRoN2jRCqUqum0jdbDLjl89n4uj2Q1ColJDJ5ajboj4GfPk2RnR9HxazbXhLTkhC4t0EhBQPtZ7jwN97cWTbQfgF+SEoPBhxt+5lCpaOXDpxAdM+nAgBAuRKOeQKOboPfAFt/9fBZe+ViqanmjbGsWMnbXobjUYTqtdwvGwmEWVgaKRsdX/jBadCI+WdPl0P/c07+OHjaRj6w0gIgoD3pgzFvo27sWftP5ArFGjerRXqt2no0uuumPkHju44DJPRZB0FfeyfI1j141Ko7PR0AoAkStY1r01GE8YPGIPbl2/CoDNAkAlQKBTw8fe1Bk6z2YyyVcvhyqlLkOw8p/mIaMnoDbJYMnpcl32/CP4hAWjUvonL3i8VPa+99hLmzluMxMQkmB9+Jn18tOj76osIDQl28GoieoShkbLlF+SP0pXL4uaF6+4upWiQgLMHT2PRpHnw8dMiJSkFtZrWwZCZn+TbqPTty7fA9N/nvQxGbFu6Gd0H9cSy6Ytg1P+7XyaXoUKtSvAPDgAA7NuwC7cu3bT2hkqiZA2fg8a/D32aDhVrV0axEmE4tGU/Zo34Ltvg+Dij3og/f16BRu2bQJeajn0bduP2lVsoWzUKDds1sXv7nui/QkOCsfnvlZj63Q/YvGU7goIC8eYbr6FH987uLo3IqwhSTu4f5aP4+FS7I0WLiuwmT/YEq35Yhj9/Xu7uMryXACCHH2+5Qg6L2QK5Qo7AYsHoN+pNRD9RPU8Thf+XJEl4/YmX7N5GFgQBP+6Zi1/H/IAjWw9CJpdBAhAcHoJhP4xEUFhGD83kt8fh1L4TNq/X+mnx5teDUatpnUzbT+45huXf/4GbF687FR61vlqMWjAOY/t+BqPeCKPeALVWDR9/H3w29ytrHd7C03/XvQ3b07XYnq7jrW0pkwkIDfWzu489jeSUbgOfh39IABaM/83dpXiVgNBAhJUIR/PurfHblz/mKDg+GhRjMVuQcOc+pgz+Bg2fbozXx7zlsuAoCALK1aiIKycv2t0/5+tf8MbYd2BKS8GRXScREhGKirUrZ7q+NsDH7mslUbK7jGLNJnVQs0kdHN1xCD9+Mj1TL6Y9ZaPL4bcvf0Rq0r9fvgadAUaDEYsnz8PAcYOdeatERJRHHD1NTmvzQjt8sXh8Rq8ZOSU5/gGKR5VA5XpV8xz0LCYLDm7ej9P7TrqougwvD+9rd3JuSZKw/689SLgbjxJRJdCofRNUqlPF5n207tkOKo3tbWKNrxYVamW9ck3dFg3wwvsvQeOrhVqrhlwhhyDLfG6VRoXn3u6F84fP2rxeEiUc3nrA2bdJRER5xJ5GypHSlcrgi0XfYFTvEe4uxWvsXrMDkig6/RxfdsxGE6Z9OAERpYujSafmaNu7PZQ5nN7mv6KiyyMqujwu2+ltVKoUuHXxBqrUiMry9VXqRePZ17tj1U/LrXM9qjQqfPj9xw6fw2zdsx2ad2uN+Ng4+AcH4PiuI1gydSFSk1IQFBaMl4b1RZkq5bJ8vcVsgSiKXIWIiKgA8JuWcqx0pbKYtYu3qXNiz7qdLjuX2WjG7cu3sHTaQnzc/UPraNC8KFM1CjI7q7pYTBYUs7PG+H8981pXTFz/PfqPHoh3J36IyRtmolTF0k5dW6FUIKJMJB7EP8D8b35H2oNUWMwWJMUl4sdPpmeaSNye2GsxTl2HiIjyhqGRckWt1WD6tl+s066QeyTcjccPH0/P9hiDzoBTe47j3KEzmSYPf1y7FzvaXREmqlp5lChX0qlaAoIDUL91Q0Q3rAGZPOdfLYsnzYU+TWed1NtitsCgM2DZ9IU2t62tBAFKlRLxsffx88jvMep/w/H72J8ZJImI8gFHT3sIbx1lde3sVYx5+RN3l1Hk+Qf7o0r9aqjWqCYexCXCZDShbssGSLgTj1+/+AEyWcbIZ7lCjvemDkXFWpVtznH+yFn8/uVPuB8TB0EQUKdFffQd+QZ8/H0K5PP5ZpNXYDLYLpsoCALqtqyPI9sO2ewLjSyG7gN74pdRszJtV6qU+HDGx6hSz/MmbvbW33VPxfZ0Lban63hrW2Y3epqh0UN464cLAFb9sBR//rzC3WWQkzS+Wkz5a5bdOQ4lSUJachpUalWmNaQL4vM5qFlfGNINNtvlSgUmrJ2OMS9/gqS4RAAZQVLr54P3pw3DuP5fQLKzRFx46eL4ZtWUfK05N7z5d90TsT1di+3pOt7altmFRt6epjzrNrAnIsuXcncZHiG0RJi7S3BMknB85xG7uwRBgF+gX6bAWBBMBiPMJvu3ziNKR+DzXsOQnpwGAJDL5VCqVRj6w6e4fOKi3cAIAHG370GXmp5vNRMRFTUMjeQSH//8OWTKov1xksllmLBmGiau+97m+UBPIooi0j0sTN26dBNKlf02S7ibgLTkVBgfrlpjsVhg1Buw4NvfkZKU9X/FCwLyPLKciIj+VbT/lSeX8Qvyx+T1M91dhlup1Bm3e0OKh2L4z6MQXjoCgkx42Hvn7+bq/mU2mVHtiRruLiMT3wA/WMz2ewwN6Xq70xVdPnkRletUsTvHJADUbFzbo8M7EZG3YWgklwkICcRP++e5uwy30fhqrH+uULMivlk1Fd9t/gkz/vkV36yegvDSEW6s7l+iRcTn/xuO8QPG4PIJ+yvBFLTw0hEoWaGUzahrlUad5a1yuVyOak/WROV60TbzNAaEBmLgN1mvFJMYl4AH95PyXDcRUVHCgTAewlsfmM2KJEn485cVWP3DMneXUuCadW+Fl4b1hUqVOeyIooi/5q3D8pl/QMxi6ht3qN28HvqPHphtb2hBfD4T4xIw9d3xuHvrLuRyGcwmM54d0AOpSanYuuRvmIz/jqxWKBV44uknMeDLt2E2mbFn7T/YsXIrzCYTmnRqjqdf7Gh3wu9bF2/gh0+mI+7WXUiQUKJcKQwcNxjFy0bm63t7XGH7XXc3tqdrsT1dx1vbkqOnvYC3frgc0aWmY8XMJTi0aR+SH6RAsti/BVkYde7fDc26tsKN89dx79YdlKpYGtWfrAVIwNXTF/H7V7/g9qVb7i7TyjfAF5/N+wrhpWx7RAvy83nr0k0kJzxAVHQ5+Pj7wqg3YtoHE3DpxAUIMhkgSShRvhSGzPgEPv721722R5eajqGd30V6yr/PcwqCAL8gf0xcN73Ann8srL/r7sL2dC22p+t4a1syNHoBb/1w5daMoVNxeOt+d5dRIB49c6dUKVGsZDhG/DzKGnbu3IjF3/PX4+zBU4iPvW+d2DonFCoFlColdKk6QAAECMjtr7VMIcOM7bOh1moybfeEz+fNi9dx6+JNFC8biahq5XO8lvf2FVuweNI8GPWZp/XR+Gjw6sgBaNS+iSvLzZIntGVhwvZ0Lban63hrW2YXGvmUOLnF2xPeh1FvxLWzl/HTpzOQcDfe3SXlm0ersFjMFty5FoPl3y9Gn4/7AQCKl4nEK5/0B5BxS3/U/0bg1sUbTp/bx98X7ft0QsdXukAml9nckt20aAMWT57n9LrXolnEztXbUaZKFILDQxDmxBKCOXXh6DksmjQXty7egF+gPzq80hntXnrGYQgsXaksSlcqm+vrxsfG2QRGADAZTdbPnz5dj73rduLyqUsoUa4knuraEgHBAbm+JhFRYcKBMOQ2Ko0KletGY8TsUShbNQpCLpae8zZmkxl71v9jd58gCGjRvXWO5kis3awuuvTvDoVSYfcZvqf/1xEBIYE5qnHhhDmY+t54jOz5ESYO+sqlcx1ePXMZk98Zh+tnr8JituBBfBJWzlqKFTP/cNk1slKhZiWofTQ22xVKJcpXr4CkuER80uNDLPluAfas/Qerf1qOj7u+n6MQT0RUmBX+f6XJ4xWLDMOoBeMwfvVUfLnkW/xyYIG7S8pXhnQDjm63XRIPAFo+1xbVG9WESqOGIM++502hUiKijOMBHBVqVMpxjfo0PUwGE84eOo1fPp/l+AVO+vOnFdb5Fh8x6g3YtGADDDrbXkBniBYR54+cxck9x6BP12d5XK2mdRFRujiUqszrpRsNRuxYuRULJsxBcsIDax0mgxG6NB1+HfNjruoiIips+Eyjh/DWZx/y269jfsSu1dvdXUa+KFGhFFp0b4PWPZ+2mWvw2tkruHjsAoLDglHzqToY/b8RiLt9D+JjA4nUPhqMWzEZQWHB2V7nxoXr+Pq1z2HUG7M9LjttX2iLSyevILBYENq99Ayin6ieq/N81OkdJNyxfRRB7aPBqPlf53gU87WzVzB18HgYDUYIEGCxWNDn4/5o2rm53eMNOj3W/roKf81bl+n5UZlcDkkU7T4LKpPLMGOH7XOeucXfdddie7oW29N1vLUtuYwgea1+n7+JkXO/zNFrCnoJvNyKuXwLiybOwYBGL+PQ1gM4d+gM4mPvAwCiosvj6f91QIO2jaDWqDH8p89RuW405EoFFCoFikeVwNBZnzoMjABQpnJZDP1hJMpVr5DrWjcv2YxrZ6/g+M4j+O79b7Hlj79ydZ4S5ewvNylaLE69l8eZjCZMemsckhOSoU/TQ5emg1FvxLxxs3H7iv1R6WqtBjWerAW5IvPj3KLFkuXgIUEQIJPbn0CciKgo4UAY8njlq1fEr4cXAQDSk1OxaPI87F5j57lAQcCYP8bj6M6DWDl9qVPnzggEMkAQIEkiRIsIQRCcHjjiKjOHToEgEyCXy1GjcS0MHPdepvAbFBaMYT+ORHpKGkxGEwJDg3J0/go1K+GzuWMxf/xv2Lrk7zzVatQbsWTqAiQnPIAgE1Cv5RMoUyXKqdd2ffM5XDh6NlOvp0qjQsvn2kJj53nD7JzedwIWi+18l2aTGTtXbUPvD/vYfd2tSzftvg4ABFnmv3u5Qo6aTevY3NImIiqKGBrJq/gE+KH/6EHoP3oQAGDFj0uReDcevd57GX6BGd3pPsG+ToXG8NLFUaNxLTR+phmiosshPSUNvgF+eJCQhKGd3s10K7ggSKIEs2jGiV3HsHDiHPQdOcDmGB9/3zxdo/UL7bBt2aY8h2KT0YQ1v6wEkPGcYtUG1fHRzE9sVnT5rwo1K+HdSUOwcOIcxF6NgY+/L9q91BGd+3XPcQ3pKel2ewdFi4jUB6lZvi68dAQUCjnMj00WDmSE1+DwECTeS4QgABAEhBYPRd/P3shxbUREhRFDI3m1Hm/2tNkWEhLi1Gt7D+mDOs3qWX/2fzi1ys3z16HWqjPmPcwFQSYgKDwYiXcScvV6UcyY9kauVOD03uPwC/RHu5eewRNPP5njuQn/q0S5kihduSxunLuWp/P817lDp/Fu6wHo0KcT2vTqkO2k29WfrIWvlk2CKIp2R3w7q2qDanZX1lFr1ajbon7W129UC4HFgmCKibNOhyQIApRqFT6f9xXu3ryDmxdvILxkOCrXi85zmxMRFRZ8ppEKpc/mfZ7t/mIlwjIFxseFFC9mDRO5IQgCJq2bgZ/3z8dLw1/LWMUkhyRRxLYlf+Pezbu4cuoSfv3iR5dNS1O5dhWXnOe/dKnpWPXDMnzc/QOkpaQ5PD4vgREAQiJC0eGVzlBp1NZtaq0aUdXKo07zrEOjTC7Dx7NHo9ZTdSGTyyGTyVC5blWMnPMltH4+iIouj2bPtkSV+tUYGImIHsPR0x7CW0dZeapH7TltyASc2HkMAcGBSE1OgUwuR6N2jdHnk/5QKLLuaP+q7+e4evaKTU9WmSpRuHf7LvTZ9EJWrF0Zn/z6hfVnSZIwYdBYnDt4Jk/vSaFUYPLGmfALynqNaGfcvHgdY/qMhMXO6jNBYcHQp+mynbrGGSqNCl3feB5Pv9gRCmX+3tA4c+AUdqzYAn2aHo06NEHDdo2dvqbFnDEAJqvj9el6HNy0F/F34hEVXR61mtZxeAveEf6uuxbb07XYnq7jrW3JZQS9gLd+uDxVXtsz4W48hnUZbPNco9ZPiwlrv8fs0TNxdPthm9fJ5DKM//M7hBYvZrNvxYw/sPbXVbmuCQAq1amM96eNgNZXm6fzbF60EUu+WwBBJgAQIMgEvDf5I0Q3rIGp73+LEzuP5un8j/gF++OblVNztEa0p4i5ehvj+o2G2WSCQWeA2keDiNLFMeKXUTketPM4/q67FtvTtdieruOtbcnQ6AW89cPlqfLanrvX7MD88b/DoMvc46bSqPG/IX3QokcbnNl/EvPH/464mHsQBAGV61VF/88HIjgi62cqY6/FYNLbX9udqzAnQoqH4oX3XkLDdo1zfY7kxGSc3nsCKo0KNRrXhlqbcZv38smLmDBwrP15HQUBJcuXwu3LN52+TvGykRi14GuXzXNYUEa/OAI3LlwHHvtaUigVCI0Mgy4tHYHFgtD5tW544uknc3Re/q67FtvTtdieruOtbcnQ6AW89cPlqfLanut+W42Vs5bYHUHd9c3n0PWN5/NSHhLuxGPX2h34a/466FJyt0yfSqNCnxH90LRLizzVYs/xnUcwf/xvSIpLhEwuQ4NWDdDp9edQvGwkZDIZjm4/hN++/AmpSc61cenKZREaWQyxV2MQXjoC7V7siOpP1nJ53bkRc/U27sfEoXTlMggOywj8yYnJ+Kjj25kmALdHpVGh+1svoP1LnZy+Hn/XXYvt6VpsT9fx1rZkaPQC3vrh8lR5bc/zR85i6uDxNkvbqbUavDPpQ1RvVDOvJVqd2ncC87/5Dfdu3gGQMZDG2V/LwGJBmLxxZr4M2JAkCbpUHVQaFSJLBNu0pyRJOLztIGYOm5KpN84ZSpUK3QY+j46vdnFhxTmTnpKG796fgOtnr0KuVMBsNKFJp2bo80l/pD1IxRAnQiOQsZrNtM0/Qql2blJ5/q67FtvTtdieruOtbckVYYhyqHLdqihfs1KmCbZVahXKVo3K9RJ6WanxZC18s2oKZuyYjTfGvoMeb/d6+KyhY8kJD2zmG3QVQRDg4++T5SARQRDQoHVDvDtxiPXWtrNMRiNW/bgU6U6MsnYlURTxz8qt+OKlT/DRM+/g8omLMBqM0KWmw2Q0Ye+G3di2dBP8gwNQqlIZp8P4/Zi4fK6ciMj9GBqJ7BAEAR9MG44eb/dCqYqlUbJCaXQb9AKGzPwkz1PFZEXr54MnOzZFp9e6ovEzzZx6jY+/LxRuXq2kbssG+H77bLTo0SZHr5PJZTh76DSS4x/g0vELuHTiQp6mOnLGz5/NwMKJc3H93FXo0/UQxcyPHxj1BmxatAEA8OZX78AvyB9qHw0EmSzLIG8xWxAQGpivdRMReQJO7k2UBYVSgXYvPoN2Lz5T4Nd+/YtBCC0eirW/rspy9RaVRoUur/fwiLkE5Qo5Xv30dTTr2gpj+4506na1Id2AWcO+swY3QSZAoVDg9S/fxhNtG7m8xttXbuHotkMwGuwM8HnMo0ndI8pEYsLa6Tiy7SDiY+MgyGVY/eMymAz/9uwq1Uo0aNMIvgH2b+UQERUmDI1EHqr7oBfQ5fUeiL16GzFXb2Pfht04f+QsDDo9fPx90eX1Hnj6fx3cXaaVaBGx/vfVUMgVMJsdPwsIIFNPnyRKMBlNmDV8Kv6qWREfTBvu0jB26dh5wEG+FmQy1GhS2/qzSqPCkx2bWn8OKhaMxZPnwagzQJQkNGrfBH1G9HNZjUREnoyhkciDKZQKlK5cFqUrl0Wj9k0gSRLMRhMUKqVTPYwXjp7Drj93wGw0oWH7Jqj1VJ18u71+4O+9OL3vhNOBMTtXTl7CB+0GYdzKKQiNtJ3zMjcCiwVn+94VKiU0Phr0GPRClsc06dQMT3ZoiqT7ifAN8PW6aYSIiPKCoZHIizxaI9kZK2ctwV/z12XcjpWAozsOodZTdTFw3OB8uaW968/tNqPN88JsMmPSO+PQd+TrKF+jUp5XlqnRuBbUWg0MOkOm0ekyuQzlqldA9SdrofUL7RDwcA3yrMjkMoREhOapFiIib8TQSFQIxd2+h41z18L02Mhqg86AE7uO4tzB04huWMPl18wqiCqUCoREhCAxLhFyuRwSAJPeaDMIxZ4712LwzYAvofHR4J2JH6JaHupWKBUY8cvnmD5kMuJu34NMJkDjq8WbX72Lqg2q5fq8RERFBUMjUSF0ev9Ju6N9DToDjv5zOF9CY9NnW+DSiQs2vY0aHw2+Wj4ZSXGJ0KWmI6JsJAY17ev8iSUJ+jQdpn0wAd+une6wJzA7EWUiMXbpBNy7dRcmowmRUSXy7XZ9fpJibkNa/ycQcxuIrg6h/TMQAjiCm4jyl/d9WxKRQ2qNGoKdMCRXyKHxydu61Vlp2K4xajatA5VGDZlcBpVGDbVWjbcnfgi5Qo7QyGIoVakMFEqFU72M/2UxW3Dw770uqTW8VARKli/lnYHx1AlIw94DNm0ETh4HVi6D9MHbkOLvu7s0Iirk8vyNuXr1anTp0gXVqlXD/PnzXVETEeVRneb1ADurysjkcjTp5NwckDklk8kw6Jv3MPSHkeg+sCd6D+mDieu/R5V60ZmOS7qfmKvnEy1mC9IepLqqXK8kSRKkmd8BBgPwKHibjEBqCqTF/P4lovyV59vT0dHRmDJlCn766SdX1ENELqD188HgyR9h+pBJwMNnDS1mM/qM6IfiZSPz7bqCIKBCzYqoULNilsfM+GgKLJacT+KtVClR1cWr8XidpCQgKdF2uygCRw8XeDlEVLTkOTRWrlwZALzyNg9RYRbdsAambvoRZw6chNlkRrWGNeHj7+PWmu7HxuHmxetZTlieFUEmoEaT2qhUp0o+VeYlNGq7PcgAAG3+PHZARPSIxwyEyWpx7KIkLMzf3SUUKmzPDCVLt3TJeVzRnqlxcVAoFJlWVcmOXC5HeOlw9Hq3F1r2aAW5XJ5pv8VswaGth3D76m1EVS2LOs3qesV/wOa+Lf2R1KgRDPv3A4/Ph6nRwO+FnvAtop95/q67FtvTdQpbWzoMjd27d0dMTIzdfXv27LH5Es+t+PhUiDnsfShMwsL8EReX4u4yCg22p2u5qj01QcF2R3ULggCZXAbRIkKpzpi4/L2pw1C5XlUc2XYQ21btwLbV/+CpLi1Qt2UDyGQyPLifhK/7jUJKYjJMRhOUKiW0fj7wC/KDJEp4qlsrtOjWGmqtOs91u1Je21J6/R0g7j5w/RogkwNmE9CkGdKatkF6EfzM83fdtdieruOtbSmTCVl25DkMjStXrnR5QURUNCmUCrzy6ev4dfQPMBlNkEQJSrUK/sH+eOWT13HtzBX4BfqhYbvG8A30w88jZ+DojkPWaXzOHTyNui0b4I2x72DO178g/k48xIfPR1rMFujT9Ui8lwAAWDxxLrb+8Te+WPSNxwXHvBD8/CB8NRHSjetA3F0gqjyEUNesmkNElB2PuT1NREVDw6cbI6J0cWxetBEJd+NRo0lttOjeBj7+PqjVtI71uCunLuHI9kMw6v+d99GgM+DItkO4fPIiTuw6CtGS/dQ9927dwa41O9DmhXb59XbcRihTFihT1t1lEFERkufQuHbtWnz77bdITk7Gli1b8NNPP+HXX39FxYpZj54koqKtbNVy6P/FoGyPOb3/ZKYVbR4xm0w4s/8U4MzTLBKwd/3OQhkaiYgKWp5DY+fOndG5c2dX1EJEZOXj7wulUpGxdvZjFEoF/AL9EN2wOs4eOO1wonAff9/8LJOIqMjw/GGGRFQkNXz6ScDuctYCnnj6Sbw6cgD8gv0dPq/4TN9n86U+IqKihqGRiDySf3AA3p00BFo/H2h8tdD4aqH188G7k4fAL8gfxSLDMH71d3h5+Gto93InBIWH2JyjTa/2qFq/mhuqJyIqfARJymqm2ILFKXe8c2i+p2J7upY729NsMuPi0XOAIKBSnSpZLkFoMVtwdMchHPh7H7S+GnR8tQuKly2R7bnvx8bh0Kb9MBmNqN28PspUzv+BJfxsuhbb07XYnq7jrW2Zpyl3iIjcSaFUILphDYfHyRVyNGjTCA3aNHLqvLv+3IF538yGJEoQRRHrfluNls+1Re8P++S1ZCKiQom3p4moyElJTMa8b2bDZDDBbDJDtIgw6o3YvnwLLp+86O7yXCI1NRWG/wwiIiLKC4ZGIipyTuw+Zne5QZPBiP0bd7uhItc5duwkWrd5FtHVG6FSlfoY8MZ7ePAg2d1lEVEhwNBIREWOIAiAYHdoNgQvWLs6K7dvx+L5F17F2XMXYDZbYDKZ8PemrfjfS6+7uzQiKgS899uRiCiXaj1V17r84OOUaiWe7NDUDRW5xpy5i2AyZZ4Q3Wg04fy5izh56oybqiKiwoKhkYiKHL9AP7z2+ZtQKBVQKBWQK+RQqlVo99IzKFe9grvLy0Q6exri6E8gDngF4piRkM6fzfLY8+cvwmhnFR2ZXIbr12/mZ5lEVAQwNBJRkRMfex9//rwCMoUcgiBAkiQ069oSPd7q5e7SMpGOHYE0dhRw+iSQlAicPA5pzGeQTh63e/wTDepCo7Gd7NxsNqNadJX8LpeICjmGRiIqcqZ9OBH3btyBUWeAyWiCaBGx688dOPbPYXeXlon020+A0ZB5o9EAac5su8e/9NIL8PXxgVz+71e7RqNB61bNUb58VD5WSkRFAUMjERUpd67H4u71WJs1q416AzYt2uimqmxJkgTE3La/8+Z1SNevQboTm2lzcHAQNm5cji6dOyIgwB8REeEY/O4b+GHW5AKomIgKO07uTURFSnpKGmQKOWCw3Zf2IBUAcObAKayctQR3b9xBifIl0eOtXqhct2qB1ikIAiQ/PyA11XanJEEaORQQRUgRkRCGfQqheCQAoFTJEpg1c1KB1kpERQN7GomoSCmdxVKBSpUS9Vs/gWP/HMG0Dybg8omLSE1KwYUj5zD57XE4c+BUAVcKoOtzgNr2GUVIEqDXA0YjcOsGpFEfQ7IzGpyIyJUYGomoSFGqlOjzcT+oNCoIsoy5GlUaFYIjQtGmVwcsmjQXRn3mlVSMBiP+mDK/wGsVnu0BdOqaERzVakAut51fUpIAXTpwyv7gGCIiV+HtaSIqchp3fAolokpi8x9/IfFePGo9VRfNu7WGSq1C3K27dl9z+/KtAq4yY6Jx4X99ID3XC3iQBGnBXGD3DtsDJQlISirw+oioaGFoJKIiqWx0OfQfPTDTNkmS4Bvgh7Rk2+cIA0MDC6o0G4JKBYSFA3XrQTq0HzDoMx9gsQBVot1THBEVGbw9TUT0kCAI6Ni3C1T/metQpVGjc//ubqrqMU2aAeERgFL17za1BmjW0joQhogov7CnkYjoMR1f6QKjzoC/5q+HKIqQK2To3K87Wj7Xxt2lQVAqga8mQFr/J7B7J6BRQ2jfCWjW0t2lEVERwNBIRPQYQRDQbWBPdO7fHSlJyfAPCoBC6TlflYJWC+G5XsBz+bN6zfETp3D8+CmULl0SzZs1gVwuz5frEJH38ZxvQiIiD6JQKhAcFuLuMgqMwWDEq30H4eDBI5AgQS6TIyQ0GKtWLEBkZIS7yyMiD8BnGomICDNm/oz9Bw4hXaeDTqdHaloabt+OxTvvDnV3aUTkIRgaiYgICxctg16feZkci8WCg4eOIjk5xU1VEZEnYWgkIiIYjaYs95nM5gKshIg8FUMjEVEhIJlMkG7egJSSnKvXd3qmHZRKpc32CuWjEBoSnNfyiKgQ4EAYIiIvJ65fAyyal/GDxQypfkMI77wPQa1x+hxDP3oX27bvRFxcPNLT06HRqKFUKjFt2vh8qpqIvA1DIxGRF5MO7gcWzgEMjz2PePgApBnfQfhwuNPn0Wg1eP+9Qdi29R+k6/Ro3LgBevV6jr2MRGTF0EhE5MWkVUszB0YAMJmAQ/shpaZC8PNzeI6Ll66ga7cXYTQaYTAYoVKpkJaejv79XsmnqonIG/GZRiIib5aQYH+7TA44+XzjmwPfR1LSA6SlpcNsNiM9PR1Hj57Azz//7ro6icjrMTQSEXmzajUAQbDdLpcDYeEOXx4TcwdXrlyHJEmZtuv1eiz6Y4WrqiSiQoC3p4mI3EyKuwdp8Xzg+FHA1w/o0g1Cm3YQ7IXB/xB6/g/Sof2AXg+IYsZGtRp4pR8EheOv+P+GxceJj85HRASGRiIit5ISEyENex9IT8sIfQ+SgN9/hnTzBoTXBjh8vVA8Evj2O0jL/wDOnAKKhUHo3hNC7bpOXb9kyUiULl0Sly5dybRdrVaj5/Ndc/GOiKiwYmgkInIjaf2fgF73by8hkDGwZdMGSD1egBAY6PAcQkRxCG+9l+safpg5GT2e7wOTyQydTgdfXx9UqlQBAwf2y/U5iajwYWgkInKnM6cAeyuuKJXAjWtAzdr5XkL16lVx6MA2rFq9DjExd9Cgfh20bPkU5HJ5vl+biLwHQyMRkTtFlgAuXgCk/zw/aDYDxcJccglRFLF06SrMnf8HTCYTnuveBa+++iI0GrX1GH9/P/R5uZdLrkdEhRNDIxGRGwldukHauxswPjbXokIJVKoCIbKES67xzrtD8dffW5GergMAXLp0BX+u3YjVKxdA4cRgGSIigFPuEBG5lVC2HISPRgChoYBSBSgUQP0GEIZ+6pLznz17Hhs2brEGRgDQ6fQ4f/4iNm3e7pJrEFHRwP/EJCJyM6FuA2DWbxkTdWu1EHx8XHbu/fsPA7CdVictLR27du1Fxw5tXXYtIircGBqJiDyAIAgZvY0uViws9OEt6MxLDarVKhQvHuHy6xFR4cXb00REhdjTbVtBpVLZbJfL5XihZ7eCL4iIvBZDIxFRIaZWq7B86RyULVsaPlotfH19UKxYKOb+PgsREY6XGSQieoS3p4mICrmqVStj7+6/cfHSFZiMJlStWolzMBJRjjE0EhEVAYIgoHKlCu4ug4i8GG9PExEREZFDDI1ERERE5BBvTxMRUcExG6G4cw6CIQ2W0LIQg1yz6g0R5T+GRiIiKhCypFho984FRBGQLIAggzm8EgwNngME3vgi8nT8LSUiovwnSdAcWAzBpIdgMUIQLRAsJijuXoDi5gl3V0dETmBoJCKifCdLvgfBpLfZLohmqM5vL/iCiCjHGBqJiKgAiFnuEXQPIHtwpwBrIaLcYGgkIqJ8JwZEAIKQ5X7FrZMFWA0R5QZDIxER5T9BBmNUfUhZ7RfNBVkNEeUCQyMRERUIc/nGgGBn+UK5EuYS1Qu+ICLKEYZGIiLKFUGfCuX5HVAfXALlhV2AMT3b4yWNHww12kGSKSAJAiQAklwJU6laEENKF0zRRJRrnKeRiIhyTJZ8D9pdvwKiBYJohnT3IpSX90DXfAAk3+AsX2cu1xCWYuWhvHUCEC0wR1aFGFwq2+cdicgzsKeRiIhyTH18DWA2QHj4LKIgmiGY9FCf2mj/BUYdVMfXwnfDt9Du/g2wmGCs0iKjhzEPgdFgMGDuvMV4vuereK3/29i+Y1euz0Web9my1XiqWQdUqlIfPZ5/BceOcQBVQWJPIxER5YwoQpZ4G/+NegIkyOOuZN4oSZDHXYb68IqMib0hQQCgvHYQ8vjr0DUfkOvQaDQa0aJVb5w+fR46nQ4AsGPHHgwa1A9Dh7ybq3OS55r1w6+YMHG69e96794D6PF8H6xetRA1a1Rzc3VFA3saiYgoZwQBkGXxz4f8sb4I0QLN3nnQ7F8MwaSD8NjYaUG0QJYaD/n9q7ku4881G3H27AVriAAAnU6HGTN+xt2793J9XvI8RqMRk6fMyPR3DQB6vQHffvudm6oqehgaiYgoZwQB5hI1IMkyj4SWZAqYytS1/qy8dgjyxFsQJItNryQAQDRDlnw312X8/fdWpKXZDr5RKpXYv/9wrs9Lnufu3XsQRdsJ4iVJwslTZ9xQUdHE0EhERDlmqNkRYmAkJLkSkkIFSa6EJbQMjFVbW49R3DgGwWLK+iRyBUSfrAfNOBIaGgK53M4UPgCCggJzfV7yPKHFQu2GRgAoW7ZMAVdTdDE0EhFRzinV0DXrD13T12Co3QW6Zq9D37hP5tvT2TyqKAkCJIUGlohKuS6hz8u9oFIpbbaLooSPhn6G+g1aYszYCUhJSc31Ncgz+Gi1eOnFntBqNZm2a7UaDPngbTdVVfQwNBIRUa6JQZEwl6wBMSDcZp+pTF1IcttQJwGwhEZB16w/ILPfU+iMatWqYOaM8fDx0cLf3w++vj5Qq1Qwm024ees2YmLvYPbseej8bC+YTNn0eJJXGD1qBF7r+xK0Wi2USgUiIsIxZfLXaN68ibtLKzIESZKyXNWpIMXHp0IUPaIUtwgL80dcXIq7yyg02J6uxfZ0nSLVlqIFmv0LIU+4CVjMD3shBeiefAliqGtuKYaF+eP6jXs4cvg4bty4iZGffwWdTp/pGF9fH0yZ9DW6dOngkmsWZt7w+TSbzUhP18Hf3w+CB8/v6Q1taY9MJiA01M/uPk65Q0RE+UMmh/7JlyFLuAF5/A1IGj+YS1QDFGqXXsZHq8VTTz2JX2ZfgGixfe4tLS0dhw4fZWgsJBQKBQIC/N1dRpHE0EhERPlHECCGloUYWjbfL1WyZAkoVUoYjMZM27VaDcqU4TKFRHnFZxqJiKhQaNumBfx8fSH7zxySCoUCPbp3dlNVRIVHnkPjF198gQ4dOuDZZ59F7969cfIkl/QhIqKCp1QqsXrVQtStUxMqlRIqlQpVqlTCimXzEBwc5O7yiLxenm9PN2/eHJ988gmUSiW2bduGDz74AJs3b3ZFbURERDlSpkwprF3zB+ITEmExmxEeHubukogKjTyHxlatWln/XKdOHdy5cweiKNrcHiAiIioooSG5nzSciOxz6ZQ733//Pc6dO4fvv//eVackIiIiIg/gsKexe/fuiImJsbtvz5491iWc1q1bhzVr1mDBggW5KoTzNHrnfE6eiu3pWmxP12Fbuhbb07XYnq7jrW2Zp3kaV65c6fACmzZtwpQpU/D777+jWLFiOa+QiIiIiDxanp9p3LZtG8aNG4fffvsNpUqVckVNRERERORh8hwaP/74YyiVSgwePNi67ffff0dwMB9CJiIiIios8hwa9+3b54o6iIiIiMiDcV4cIiIiInKIoZGIiIiIHGJoJCIiIiKHGBqJiIiIyCGGRiIiIiJyiKGRiIiIiBxiaCQiIiIihxgaiYiIiMghhkYiIiIicoihkYiIiIgcYmgkIiIiIocYGomIiIjIIYZGIiIiInKIoZGIiIiIHGJoJCIiIiKHGBqJiIiIyCGFuwsgIiIiQJIk7N69H2vX/QWlUoGePbuhVs3q7i6LyIqhkYiIyM0kScL7H36CtWs3Ij1dB5lMhvkLluLDD97Cu++84e7yiADw9jQREZHb7dt/yBoYAUAURej1ekya/D1u3451c3VEGRgaiYiI3GzDxs3Q6fQ222UyObZt3+mGiohsMTQSERG5mVajgUxm+0+yTCZArVa7oSIiWwyNREREbtajRxcolUqb7aIooX271m6oiMgWQyMREZGbValcEZ9/NhRqtRq+vj7w8/OFVqvFzz99h4AAf3eXRwSAo6eJiIg8wmt9X0KXzh2wbfsuqJRKtGnTHH5+fu4ui8iKoZGIiMhDFCsWip7Pd3V3GUR28fY0ERERETnE0EhEREREDjE0EhEREZFDDI1ERERE5BBDIxERERE5xNBIRERERA4xNBIRERGRQ5ynkYiIyEtpkQQVTNafJQDJCAJguyQhUV6xp5GIiMgLqZEMFUwQBPz7PwCBSHJ3aVRIMTQSERF5IQ0MNtsEIeP/lUgv4GqoKGBoJCIi8lKPQuJ/Ke0ESqK8YmgkIiLyUpJkf7sJ6oIthIoEhkYiIiIvpLcTDB+FSBN8CrgaKgoYGomIiLyQAQEwQQFJgvV/APAAQW6tiwovTrlDRETkpdIR/PBPj6bd4VQ7lH8YGomIiLwewyLlP96eJiIiIiKHGBqJiIiIyCGGRiIiIiJyiKGRiIiIiBxiaCQiIiIihxgaiYiIiMghhkYiIiIicoihkYiIiIgcYmgkIiIiIocYGomIiIjIIYZGIiIiInKIoZGIiIiIHGJoJCIiIiKHGBqJiIiIyCGGRiIiIiJyiKGRiIiIiBxSuLsAIiIi8jzp6enYs+cAFEoFmjRuCJVK5e6SyM0YGomIiCiTNWs24r0PPoZCLgcEQBAE/PbrDDRp3NDdpZEb8fY0ERERWd28eQuD3x8BnU6HlNRUpKSkIjk5Ba+8OhCpqanuLo/ciKGRiIiIrJavWAOLxWJ334aNWwq4GvIkDI1ERERk9eBBMkwmk812i8XCnsYijqGRiIiIrNq0bgEfHx/bHRLQonnTgi+IPAZDIxEREVk1bdoILVs0hY+P1rrNx0eLV175H8qXj3JfYeR2HD1NREREVoIg4OefvsOGjZuxYsUaqFRK9O79HJo3a+Lu0sjNGBqJiIgoE5lMhk7PtEOnZ9q5uxTyIHkOjbNmzcL69eshl8shSRLefPNNPPPMM66ojYiIiIg8RJ5D48svv4xBgwYBAO7evYuOHTuiadOmCAwMzHNxREREROQZ8jwQxt/f3/rn9PR0CIIAURTzeloiIiIi8iCCJElSXk+yaNEizJkzB3fu3MHXX3/N29NEREREhYzD0Ni9e3fExMTY3bdnzx7I5XLrz+fPn8dHH32EuXPnIjg4OEeFxMenQhTznF+9VliYP+LiUtxdRqHB9nQttqfrsC1di+3pWmxP1/HWtpTJBISG+tnd5/CZxpUrVzp9oSpVqiA8PBwHDhxA+/btna+QiIiIiDxanp9pvHTpkvXPN2/exNmzZ1GxYsW8npaIiIiIPEieR09Pnz4dly5dgkKhgFwux8iRI1GhQgVX1EZEREREHiLPofG7775zRR1ERERE5MG49jQREREROcTQSEREREQOMTQSERERkUMMjUREREQFJD09HbN+mI0OHZ/H8z1fxdp1f8EF66wUiDwPhCEiIiIixwwGIzo/2xtXr96AXq8HABw9dgIHDh7BmNEfu7k6x9jTSERERFQAVq9eh+vXb1oDIwCkp+swd+5i3L4d68bKnMPQSERERFQAtmz9B+npOpvtSqUCBw4edkNFOcPQSERERFQAihcPh0Jh/8nAYqGhBVxNzjE0EhERERWAPi/3glKZOTQKggB/fz80adLQTVU5j6GRiIiIqABUrFge30+fgIAAf/j5+UKr1aJC+SgsWzIHcrk807HXrt3AK68ORFT52qharSG+GDMeer3BTZVn4OhpIiIiogLyTMen8XTbljh9+hy0PlpUrlQBgiBkOiY+IREdO/VEcnIKRFGEwWDAb78vxLnzF7FowS9uqpyhkYiIiKhAKZVK1KlTM8v98+Ythl6vhyiK1m0GgwH79x/C+fMXUaVKpYIo0wZvTxMRERF5kOMnTtu9FS2Xy3H+/CU3VJSBoZGIiIjIg1SLrgKVSmWzXbSIKF8+quALeoihkYiIiMiDvNKnF9TqzKFRpVKhRs1qqFEj2k1VMTQSEREReZSIiHCsXrkATzSoC5lMBpVKhe7dO2PBvB/dWhcHwhARERF5mOjoKvhz9SKYzWbIZDLIZO7v52NoJCIiIvJQWa0g4w7uj61ERERE5PEYGomIiIjIIYZGIiIiInKIoZGIiIiIHGJoJCIiIiKHGBqJiIiIyCGGRiIiIiJyiKGRiIiIiBxiaCQiIiIihxgaiYiIiMghhkYiIiIicoihkYiIiIgcYmgkIiIiIocU7i7gEZlMcHcJbsc2cC22p2uxPV2HbelabE/XYnu6jje2ZXY1C5IkSQVYCxERERF5Id6eJiIiIiKHGBqJiIiIyCGGRiIiIiJyiKGRiIiIiBxiaCQiIiIihxgaiYiIiMghhkYiIiIicoihkYiIiIgcYmgkIiIiIocYGomIiIjIIY9Ze7qo+eKLL7B3716oVCr4+Pjg008/Rc2aNW2OW7FiBb7++muULFkSAFCqVCnMmDGjoMv1SFevXsWIESOQlJSEoKAgjB8/HlFRUZmOsVgsGDt2LHbu3AlBEPDGG2+gZ8+e7inYgyUmJmLYsGG4ceMGVCoVypYtizFjxiAkJCTTcSNGjMCePXsQHBwMAOjQoQMGDRrkjpI9WuvWraFSqaBWqwEAH330EZo1a5bpGJ1Oh48//hinT5+GXC7H8OHD0apVK3eU69Fu3bqFt99+2/pzSkoKUlNTceDAgUzHTZ8+HQsXLkR4eDgAoF69ehg1alSB1uqpxo8fj7/++gu3b9/GmjVrULlyZQDOfYcC/B59nL22dPb7EygE36ESucXWrVslo9Fo/XObNm3sHrd8+XLp3XffLcjSvEafPn2kVatWSZIkSatWrZL69Oljc8zKlSulfv36SRaLRYqPj5eaNWsm3bx5s6BL9XiJiYnSvn37rD9/88030scff2xz3PDhw6V58+YVZGleqVWrVtL58+ezPWb69OnSp59+KkmSJF29elVq0qSJlJqaWhDlebWxY8dKX3zxhc32adOmSd98840bKvJ8Bw8elGJiYmw+l858h0oSv0cfZ68tnf3+lCTv/w7l7Wk3adWqFZRKJQCgTp06uHPnDkRRdHNV3iM+Ph5nzpxB586dAQCdO3fGmTNnkJCQkOm49evXo2fPnpDJZAgJCUHbtm2xceNGd5Ts0YKCgtCoUSPrz3Xq1EFMTIwbKyr8NmzYgF69egEAoqKiUKNGDfzzzz9ursqzGY1GrFmzBs8995y7S/EqDRo0QGRkZKZtzn6HAvwefZy9tixK358MjR5gwYIFaNmyJWQy+38dBw4cQNeuXfHSSy9h+/btBVuch4qNjUVERATkcjkAQC6XIzw8HLGxsTbHlShRwvpzZGQk7ty5U6C1ehtRFLFo0SK0bt3a7v7ffvsNXbp0wVtvvYXLly8XcHXe46OPPkKXLl0wevRoJCcn2+yPiYmxPnYC8LPpjK1btyIiIgLVq1e3u3/dunXo0qUL+vXrh6NHjxZwdd7F2e/QR8fye9Q5jr4/Ae/+DuUzjfmke/fuWf6Xxp49e6y/qOvWrcOaNWuwYMECu8e2bNkSzzzzDDQaDc6cOYMBAwZg7ty5qFChQr7VTkXbl19+CR8fH7z88ss2+z744AOEhYVBJpNh1apVeP3117F582br55kyLFiwAJGRkTAajfjqq68wZswYTJw40d1leb3ly5dn2cvYu3dvDBw4EEqlErt378Zbb72F9evXW58dIyoI2X1/At7/HcqexnyycuVK7N+/3+7/Hn04Nm3ahClTpmD27NkoVqyY3fOEhIRAo9EAAKpVq4Z69erhxIkTBfY+PFVkZCTu3r0Li8UCIONB7Xv37tncNoiMjMwU3mNjY1G8ePECrdWbjB8/HtevX8fUqVPt9nxHRERYt3fr1g3p6enscbDj0edQpVLhxRdfxJEjR2yOKVGiBG7fvm39mZ/N7N29excHDx5Ely5d7O4PCwuzPvLTtGlTREZG4uLFiwVZoldx9jv00bH8HnXM0fcn4P3foQyNbrJt2zaMGzcOs2fPRqlSpbI87u7du9Y/3759G8eOHUOVKlUKokSPFhoaiujoaKxduxYAsHbtWkRHR9uMVuvQoQOWLl0KURSRkJCAzZs3o3379u4o2eNNnjwZp06dwowZM6BSqewe8/jncefOnZDJZIiIiCioEr1Ceno6UlJSAACSJGH9+vWIjo62Oa5Dhw74448/AADXrl3DyZMnbUZY079WrlyJFi1aZNlz+Phn8+zZs7h9+zbKlStXUOV5HWe/QwF+jzrDme9PwPu/QwVJkiR3F1EUPfnkk1AqlZl+QX///XcEBwfj008/RevWrdGmTRtMnjwZW7ZssfZOvvbaa+jevbu7yvYoly9fxogRI5CcnIyAgACMHz8e5cuXx4ABAzB48GDUrFkTFosFY8aMwe7duwEAAwYMsA4+oH9dvHgRnTt3RlRUlLVn+9H0Tl27dsVPP/2EiIgI9O3bF/Hx8RAEAX5+fhg2bBjq1Knj3uI9zM2bN/Huu+/CYrFAFEVUqFABI0eORHh4eKa2TE9Px4gRI3D27FnIZDIMHToUbdu2dXf5Hqt9+/b49NNP0bx5c+u2x3/Xhw8fjtOnT0Mmk0GpVGLw4MFo0aKFGyv2HGPHjsXff/+N+/fvIzg4GEFBQVi3bl2W36EA+D2aBXttOXXq1Cy/PwEUqu9QhkYiIiIicoi3p4mIiIjIIYZGIiIiInKIoZGIiIiIHGJoJCIiIiKHGBqJiIiIyCGGRiIiIiJyiKGRiIiIiBz6P3BcqgJqJHzVAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 792x576 with 1 Axes>"
       ]
@@ -1830,7 +1825,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1849,7 +1844,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [
     {
@@ -1864,7 +1859,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 47,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1878,7 +1873,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1916,7 +1911,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
@@ -1948,33 +1943,33 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>operator.Run cluster install and upgrade e2e-a...</td>\n",
-       "      <td>0.558506</td>\n",
-       "      <td>0.868667</td>\n",
+       "      <td>[Feature:Platform] ClusterOperators should def...</td>\n",
+       "      <td>0.320792</td>\n",
+       "      <td>0.600181</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>[Feature:OpenShiftAuthorization] scopes TestSc...</td>\n",
-       "      <td>0.325655</td>\n",
-       "      <td>0.591332</td>\n",
+       "      <td>[sig-storage] Zone Support [Top Level] [sig-st...</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.739335</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>[sig-storage] In-tree Volumes [Driver: local][...</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0.765701</td>\n",
+       "      <td>operator.Run template e2e-gcp-serial - e2e-gcp...</td>\n",
+       "      <td>1.902771</td>\n",
+       "      <td>2.258621</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>[sig-storage] In-tree Volumes [Driver: local][...</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>1.181719</td>\n",
+       "      <td>[sig-storage] Downward API volume [Top Level] ...</td>\n",
+       "      <td>0.306030</td>\n",
+       "      <td>0.568613</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>[Feature:OAuthServer] [Headers] expected heade...</td>\n",
-       "      <td>0.759769</td>\n",
-       "      <td>0.904425</td>\n",
+       "      <td>[sig-storage] In-tree Volumes [Driver: azure] ...</td>\n",
+       "      <td>0.094791</td>\n",
+       "      <td>0.530946</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1982,21 +1977,21 @@
       ],
       "text/plain": [
        "                                                test  local average distance  \\\n",
-       "0  operator.Run cluster install and upgrade e2e-a...                0.558506   \n",
-       "1  [Feature:OpenShiftAuthorization] scopes TestSc...                0.325655   \n",
-       "2  [sig-storage] In-tree Volumes [Driver: local][...                0.000000   \n",
-       "3  [sig-storage] In-tree Volumes [Driver: local][...                0.000000   \n",
-       "4  [Feature:OAuthServer] [Headers] expected heade...                0.759769   \n",
+       "0  [Feature:Platform] ClusterOperators should def...                0.320792   \n",
+       "1  [sig-storage] Zone Support [Top Level] [sig-st...                0.000000   \n",
+       "2  operator.Run template e2e-gcp-serial - e2e-gcp...                1.902771   \n",
+       "3  [sig-storage] Downward API volume [Top Level] ...                0.306030   \n",
+       "4  [sig-storage] In-tree Volumes [Driver: azure] ...                0.094791   \n",
        "\n",
        "   global average distance  \n",
-       "0                 0.868667  \n",
-       "1                 0.591332  \n",
-       "2                 0.765701  \n",
-       "3                 1.181719  \n",
-       "4                 0.904425  "
+       "0                 0.600181  \n",
+       "1                 0.739335  \n",
+       "2                 2.258621  \n",
+       "3                 0.568613  \n",
+       "4                 0.530946  "
       ]
      },
-     "execution_count": 48,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2007,7 +2002,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [
     {
@@ -2016,7 +2011,7 @@
        "0.9842267248012311"
       ]
      },
-     "execution_count": 49,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2071,7 +2066,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2097,7 +2092,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2119,7 +2114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [
     {
@@ -2182,7 +2177,7 @@
        "1  {'Application behind service load balancer wit...  "
       ]
      },
-     "execution_count": 52,
+     "execution_count": 53,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2196,7 +2191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2210,7 +2205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [
     {
@@ -2279,7 +2274,7 @@
        "1  {'Application behind service load balancer wit...      56      77  "
       ]
      },
-     "execution_count": 54,
+     "execution_count": 55,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2290,7 +2285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 56,
    "metadata": {},
    "outputs": [
     {
@@ -2299,7 +2294,7 @@
        "0.6028508219887826"
       ]
      },
-     "execution_count": 55,
+     "execution_count": 56,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2333,7 +2328,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 57,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2342,7 +2337,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 58,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2380,7 +2375,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 59,
    "metadata": {},
    "outputs": [
     {
@@ -2418,7 +2413,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 60,
    "metadata": {},
    "outputs": [
     {
@@ -2492,7 +2487,7 @@
        "4  [2020-10-07 18:04:59, 2020-10-06 18:04:21, 202...  "
       ]
      },
-     "execution_count": 59,
+     "execution_count": 60,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2505,7 +2500,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 61,
    "metadata": {},
    "outputs": [
     {
@@ -2579,7 +2574,7 @@
        "4  [2020-10-07, 2020-10-06, 2020-10-05, 2020-10-0...  "
       ]
      },
-     "execution_count": 60,
+     "execution_count": 61,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2595,7 +2590,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 62,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2611,7 +2606,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 63,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2626,7 +2621,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 64,
    "metadata": {},
    "outputs": [
     {
@@ -2691,7 +2686,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 65,
    "metadata": {},
    "outputs": [
     {
@@ -2701,7 +2696,7 @@
        "<IPython.core.display.Image object>"
       ]
      },
-     "execution_count": 64,
+     "execution_count": 65,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2714,7 +2709,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 66,
    "metadata": {},
    "outputs": [
     {
@@ -2724,7 +2719,7 @@
        "       [ 1, -1]])"
       ]
      },
-     "execution_count": 65,
+     "execution_count": 66,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2737,7 +2732,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 67,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2748,7 +2743,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 68,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2759,7 +2754,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2779,7 +2774,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 70,
    "metadata": {},
    "outputs": [
     {
@@ -2801,7 +2796,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 71,
    "metadata": {},
    "outputs": [
     {
@@ -2825,7 +2820,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 72,
    "metadata": {},
    "outputs": [
     {
@@ -2834,7 +2829,7 @@
        "(array([1, 3]), array([5, 6]))"
       ]
      },
-     "execution_count": 71,
+     "execution_count": 72,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2848,7 +2843,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 73,
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
## Related Issues and Dependencies

closes #43
#40  

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

This PR includes 3 updates, all focused on ensuring reproduciblity when deployed as an image on JH. 
* Updated Pipfiles to reflect notebook requirements 
* Included a sample TestGrid Dataset (4.5MB) used to recreate the results in "notebooks/TestGrid_indepth_EDA.ipynb"
* Removed dependency on the "nbimporter" packages which was breaking pre-commit check and is also no longer considered best practice for sharing functions between notebooks. See #43   
