### PR TITLE
added video to project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ DevOps engineers.
 ## Current Work
 
 * Interactive and reproducible notebooks for the [entire project](https://github.com/aicoe-aiops/ocp-ci-analysis) are available as an image on a public [jupyterhub](https://jupyterhub-opf-jupyterhub.apps.cnv.massopen.cloud/hub/login) instance on the MOC.
-* Video explainer (forthcoming)
+* The following video describes the TestGrid ecosystem and data source as well as existing tools to access and prepare data for analysis with python.
+
+`video: https://www.youtube.com/watch?v=lY75bDv6kd4&feature=youtu.be`
 
 
 ## Active Projects:


### PR DESCRIPTION
## Related Issues and Dependencies

Add video tutorial to the README so that the [page](https://www.operate-first.cloud/data-science/ocp-ci-analysis/) on the operate first site contains a preview to the explainer YouTube video.

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

https://github.com/operate-first/operate-first.github.io/issues/161

## Description

Adds video in required format to markdown. 
https://github.com/operate-first/operate-first.github.io/blob/master/content/examples/markdown.md#add-videos