### PR TITLE
Bucket claim cannot contain the '_' character.

### DIFF
--- a/manifests/buckets.yaml
+++ b/manifests/buckets.yaml
@@ -1,9 +1,9 @@
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
 metadata:
-  name: black_flake
+  name: black-flake
 spec:
-  generateBucketName: black_flake-
+  generateBucketName: black-flake-
   storageClassName: ocs-storagecluster-ceph-rgw
   additionalConfig:
     maxObjects: "1000"


### PR DESCRIPTION
Fixes bug when claiming the bucket:

```
  ObjectBucketClaim.objectbucket.io "black_flake" is invalid:
  metadata.name: Invalid value: "black_flake": a DNS-1123 subdomain must
  consist of lower case alphanumeric characters, '-' or '.', and must
  start and end with an alphanumeric character (e.g. 'example.com', regex
  used for validation is
  '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```

## Related Issues and Dependencies

Follow up for:
https://github.com/aicoe-aiops/ocp-ci-analysis/pull/111

## This introduces a breaking change

- [ ] Yes
- [x] No


pint @tumido , @MichaelClifford 
