### PR TITLE
Rebuild image using Elyra

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -6,7 +6,7 @@ check:
 build:
   build-stratergy: Source
   build-source-script: "image:///opt/app-root/builder"
-  base-image: quay.io/thoth-station/s2i-custom-py38-notebook:latest
+  base-image: quay.io/thoth-station/s2i-elyra-custom-notebook:latest
   custom-tag: latest
   registry: quay.io
   registry-org: aicoe


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Related-To: https://github.com/aicoe-aiops/ocp-ci-analysis/issues/109

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Change base image to have s2i lab Elyra as base.


@martinpovolny No other changes seems to be required, as the image will pick latest tag and ArgoCD already watches the imagestream related: https://github.com/operate-first/apps/blob/master/odh/base/jupyterhub/notebook-images/ocp-ci-analysis.yaml
