### PR TITLE
Add KPI notebook for percent test fixed each run

### DIFF
--- a/notebooks/data-sources/TestGrid/metrics/pct_fixed_each_ts.ipynb
+++ b/notebooks/data-sources/TestGrid/metrics/pct_fixed_each_ts.ipynb
@@ -1,0 +1,591 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "charming-pioneer",
+   "metadata": {},
+   "source": [
+    "# Percent of Failing Tests Fixed\n",
+    "\n",
+    "This notebook is an addition to the series of KPI notebook in which we calculate key performance indicators for CI processes. In this notebook, we will calculate the KPI \"Percent of failing tests fixed in each run/timestamp\". Essentially we will determine what percent of tests that were failing in the previous test run got fixed in the current test run.\n",
+    "\n",
+    "For OpenShift managers, this information can potentially help quantify the agility and efficiency of their team. If this number is high, it means they are able to quickly identify the root causes of all failing tests in the previous run and fix them. Conversely if this number is low, it means only a small percent of previously failing tests get fixed in each new run, which in turn implies that their CI process is likely not as efficient as it could be."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "textile-mortgage",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-02-08T22:09:14.897443Z",
+     "start_time": "2021-02-08T22:09:14.371522Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "import gzip\n",
+    "import json\n",
+    "import datetime as dt\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "sys.path.append(\"../../..\")\n",
+    "\n",
+    "module_path_1 = os.path.abspath(os.path.join(\"../../../data-sources/TestGrid\"))\n",
+    "if module_path_1 not in sys.path:\n",
+    "    sys.path.append(module_path_1)\n",
+    "\n",
+    "from ipynb.fs.defs.number_of_flakes import (  # noqa: E402\n",
+    "    testgrid_labelwise_encoding,\n",
+    ")  # noqa: E402\n",
+    "\n",
+    "from ipynb.fs.defs.testgrid_EDA import decode_run_length  # noqa: E402"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "realistic-struggle",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-02-08T22:09:19.031967Z",
+     "start_time": "2021-02-08T22:09:15.200904Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Load test file\n",
+    "with gzip.open(\"../../../../data/raw/testgrid_810.json.gz\", \"rb\") as read_file:\n",
+    "    data = json.load(read_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "needed-highlight",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\"redhat-openshift-informing\"\n",
+      "\"redhat-openshift-ocp-release-3.11-informing\"\n",
+      "\"redhat-openshift-ocp-release-4.1-blocking\"\n",
+      "\"redhat-openshift-ocp-release-4.1-informing\"\n",
+      "\"redhat-openshift-ocp-release-4.2-blocking\"\n",
+      "\"redhat-openshift-ocp-release-4.2-informing\"\n",
+      "\"redhat-openshift-ocp-release-4.3-blocking\"\n",
+      "\"redhat-openshift-ocp-release-4.3-broken\"\n",
+      "\"redhat-openshift-ocp-release-4.3-informing\"\n",
+      "\"redhat-openshift-ocp-release-4.4-blocking\"\n",
+      "\"redhat-openshift-ocp-release-4.4-broken\"\n",
+      "\"redhat-openshift-ocp-release-4.4-informing\"\n",
+      "\"redhat-openshift-ocp-release-4.5-blocking\"\n",
+      "\"redhat-openshift-ocp-release-4.5-broken\"\n",
+      "\"redhat-openshift-ocp-release-4.5-informing\"\n",
+      "\"redhat-openshift-ocp-release-4.6-blocking\"\n",
+      "\"redhat-openshift-ocp-release-4.6-broken\"\n",
+      "\"redhat-openshift-ocp-release-4.6-informing\"\n",
+      "\"redhat-openshift-ocp-release-4.7-blocking\"\n",
+      "\"redhat-openshift-ocp-release-4.7-broken\"\n",
+      "\"redhat-openshift-ocp-release-4.7-informing\"\n",
+      "\"redhat-openshift-okd-release-4.3-informing\"\n",
+      "\"redhat-openshift-okd-release-4.4-informing\"\n",
+      "\"redhat-openshift-okd-release-4.5-blocking\"\n",
+      "\"redhat-openshift-okd-release-4.5-informing\"\n",
+      "\"redhat-openshift-okd-release-4.6-blocking\"\n",
+      "\"redhat-openshift-okd-release-4.6-informing\"\n",
+      "\"redhat-openshift-okd-release-4.7-informing\"\n",
+      "\"redhat-openshift-presubmit-master-gcp\"\n",
+      "\"redhat-osde2e-int-aws\"\n",
+      "\"redhat-osde2e-int-gcp\"\n",
+      "\"redhat-osde2e-int-moa\"\n",
+      "\"redhat-osde2e-prod-aws\"\n",
+      "\"redhat-osde2e-prod-gcp\"\n",
+      "\"redhat-osde2e-prod-moa\"\n",
+      "\"redhat-osde2e-stage-aws\"\n",
+      "\"redhat-osde2e-stage-gcp\"\n",
+      "\"redhat-osde2e-stage-moa\"\n"
+     ]
+    }
+   ],
+   "source": [
+    "# NOTE: this for loop is a modified version of the testgrid_labelwise_encoding function\n",
+    "# We've adapted this loop to put a \"True\" if a test was fixed in the current run, and\n",
+    "# \"False\" otherwise. Basically instead of indicating \"is_flake\" or \"is_pass\" etc., it\n",
+    "# now indicates \"is passing now but was failing before\" aka \"is_flip\"\n",
+    "percent_label_by_grid_csv = []\n",
+    "\n",
+    "for tab in data.keys():\n",
+    "    print(tab)\n",
+    "\n",
+    "    for grid in data[tab].keys():\n",
+    "        current_grid = data[tab][grid]\n",
+    "\n",
+    "        # get all timestamps for this grid (x-axis of grid)\n",
+    "        timestamps = [\n",
+    "            dt.datetime.fromtimestamp(t // 1000) for t in current_grid[\"timestamps\"]\n",
+    "        ]\n",
+    "\n",
+    "        tests = []\n",
+    "        all_tests_did_get_fixed = []\n",
+    "\n",
+    "        # NOTE: this list of dicts goes from most recent to least recent\n",
+    "        for i, current_test in enumerate(current_grid[\"grid\"]):\n",
+    "            tests.append(current_test[\"name\"])\n",
+    "            statuses_decoded = decode_run_length(current_grid[\"grid\"][i][\"statuses\"])\n",
+    "\n",
+    "            did_get_fixed = []\n",
+    "            for status_i in range(0, len(statuses_decoded) - 1):\n",
+    "                did_get_fixed.append(\n",
+    "                    statuses_decoded[status_i] == 1\n",
+    "                    and statuses_decoded[status_i + 1] == 12\n",
+    "                )\n",
+    "\n",
+    "            # the least recent test cannot have \"True\", assuming it wasnt failing before\n",
+    "            did_get_fixed.append(False)\n",
+    "\n",
+    "            # add results for all timestamps for current test\n",
+    "            all_tests_did_get_fixed.append(np.array(did_get_fixed))\n",
+    "\n",
+    "        all_tests_did_get_fixed = [\n",
+    "            list(zip(timestamps, g)) for g in all_tests_did_get_fixed\n",
+    "        ]\n",
+    "\n",
+    "        # add the test, tab and grid name to each entry\n",
+    "        # TODO: any ideas for avoiding this quad-loop\n",
+    "        for i, d in enumerate(all_tests_did_get_fixed):\n",
+    "            for j, k in enumerate(d):\n",
+    "                all_tests_did_get_fixed[i][j] = (k[0], tab, grid, tests[i], k[1])\n",
+    "\n",
+    "        # accumulate the results\n",
+    "        percent_label_by_grid_csv.append(all_tests_did_get_fixed)\n",
+    "\n",
+    "# output above leaves us with a doubly nested list. Flatten\n",
+    "flat_list = [item for sublist in percent_label_by_grid_csv for item in sublist]\n",
+    "flatter_list = [item for sublist in flat_list for item in sublist]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "eastern-delicious",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(datetime.datetime(2020, 10, 8, 20, 48, 5),\n",
+       " '\"redhat-openshift-informing\"',\n",
+       " 'release-openshift-okd-installer-e2e-aws-upgrade',\n",
+       " 'Application behind service load balancer with PDB is not disrupted',\n",
+       " False)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "flatter_list[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "legal-lease",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>timestamp</th>\n",
+       "      <th>tab</th>\n",
+       "      <th>grid</th>\n",
+       "      <th>test</th>\n",
+       "      <th>did_get_fixed</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2020-10-08 20:48:05</td>\n",
+       "      <td>\"redhat-openshift-informing\"</td>\n",
+       "      <td>release-openshift-okd-installer-e2e-aws-upgrade</td>\n",
+       "      <td>Application behind service load balancer with ...</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2020-10-08 19:12:01</td>\n",
+       "      <td>\"redhat-openshift-informing\"</td>\n",
+       "      <td>release-openshift-okd-installer-e2e-aws-upgrade</td>\n",
+       "      <td>Application behind service load balancer with ...</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2020-10-08 14:18:13</td>\n",
+       "      <td>\"redhat-openshift-informing\"</td>\n",
+       "      <td>release-openshift-okd-installer-e2e-aws-upgrade</td>\n",
+       "      <td>Application behind service load balancer with ...</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2020-10-08 11:15:28</td>\n",
+       "      <td>\"redhat-openshift-informing\"</td>\n",
+       "      <td>release-openshift-okd-installer-e2e-aws-upgrade</td>\n",
+       "      <td>Application behind service load balancer with ...</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2020-10-08 08:27:53</td>\n",
+       "      <td>\"redhat-openshift-informing\"</td>\n",
+       "      <td>release-openshift-okd-installer-e2e-aws-upgrade</td>\n",
+       "      <td>Application behind service load balancer with ...</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "            timestamp                           tab  \\\n",
+       "0 2020-10-08 20:48:05  \"redhat-openshift-informing\"   \n",
+       "1 2020-10-08 19:12:01  \"redhat-openshift-informing\"   \n",
+       "2 2020-10-08 14:18:13  \"redhat-openshift-informing\"   \n",
+       "3 2020-10-08 11:15:28  \"redhat-openshift-informing\"   \n",
+       "4 2020-10-08 08:27:53  \"redhat-openshift-informing\"   \n",
+       "\n",
+       "                                              grid  \\\n",
+       "0  release-openshift-okd-installer-e2e-aws-upgrade   \n",
+       "1  release-openshift-okd-installer-e2e-aws-upgrade   \n",
+       "2  release-openshift-okd-installer-e2e-aws-upgrade   \n",
+       "3  release-openshift-okd-installer-e2e-aws-upgrade   \n",
+       "4  release-openshift-okd-installer-e2e-aws-upgrade   \n",
+       "\n",
+       "                                                test  did_get_fixed  \n",
+       "0  Application behind service load balancer with ...          False  \n",
+       "1  Application behind service load balancer with ...          False  \n",
+       "2  Application behind service load balancer with ...          False  \n",
+       "3  Application behind service load balancer with ...          False  \n",
+       "4  Application behind service load balancer with ...          False  "
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# this df indicates whether a test was fixed or not at a given timestamp (as compared to previous one)\n",
+    "df_csv = pd.DataFrame(\n",
+    "    flatter_list, columns=[\"timestamp\", \"tab\", \"grid\", \"test\", \"did_get_fixed\"]\n",
+    ")\n",
+    "df_csv.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "operational-prairie",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tab                           grid                                             timestamp          \n",
+       "\"redhat-openshift-informing\"  release-openshift-okd-installer-e2e-aws-upgrade  2020-09-23 22:16:02    0\n",
+       "                                                                               2020-09-24 00:04:39    1\n",
+       "                                                                               2020-09-24 01:57:00    0\n",
+       "                                                                               2020-09-24 03:48:47    6\n",
+       "                                                                               2020-09-24 05:36:09    0\n",
+       "                                                                                                     ..\n",
+       "\"redhat-osde2e-stage-moa\"     osde2e-stage-moa-e2e-upgrade-default-next        2020-10-07 08:01:13    0\n",
+       "                                                                               2020-10-07 16:01:54    0\n",
+       "                                                                               2020-10-08 00:01:28    0\n",
+       "                                                                               2020-10-08 08:02:28    0\n",
+       "                                                                               2020-10-08 16:01:08    0\n",
+       "Name: did_get_fixed, Length: 32663, dtype: int64"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# each element in this multiindexed series tells how many tests got fixed at each run/timestamp\n",
+    "num_fixed_per_ts = df_csv.groupby([\"tab\", \"grid\", \"timestamp\"]).did_get_fixed.sum()\n",
+    "num_fixed_per_ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "stainless-congress",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>timestamp</th>\n",
+       "      <th>tab</th>\n",
+       "      <th>job</th>\n",
+       "      <th>test</th>\n",
+       "      <th>failure</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2020-10-08 20:48:05</td>\n",
+       "      <td>\"redhat-openshift-informing\"</td>\n",
+       "      <td>release-openshift-okd-installer-e2e-aws-upgrade</td>\n",
+       "      <td>Application behind service load balancer with ...</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2020-10-08 19:12:01</td>\n",
+       "      <td>\"redhat-openshift-informing\"</td>\n",
+       "      <td>release-openshift-okd-installer-e2e-aws-upgrade</td>\n",
+       "      <td>Application behind service load balancer with ...</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2020-10-08 14:18:13</td>\n",
+       "      <td>\"redhat-openshift-informing\"</td>\n",
+       "      <td>release-openshift-okd-installer-e2e-aws-upgrade</td>\n",
+       "      <td>Application behind service load balancer with ...</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2020-10-08 11:15:28</td>\n",
+       "      <td>\"redhat-openshift-informing\"</td>\n",
+       "      <td>release-openshift-okd-installer-e2e-aws-upgrade</td>\n",
+       "      <td>Application behind service load balancer with ...</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2020-10-08 08:27:53</td>\n",
+       "      <td>\"redhat-openshift-informing\"</td>\n",
+       "      <td>release-openshift-okd-installer-e2e-aws-upgrade</td>\n",
+       "      <td>Application behind service load balancer with ...</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "            timestamp                           tab  \\\n",
+       "0 2020-10-08 20:48:05  \"redhat-openshift-informing\"   \n",
+       "1 2020-10-08 19:12:01  \"redhat-openshift-informing\"   \n",
+       "2 2020-10-08 14:18:13  \"redhat-openshift-informing\"   \n",
+       "3 2020-10-08 11:15:28  \"redhat-openshift-informing\"   \n",
+       "4 2020-10-08 08:27:53  \"redhat-openshift-informing\"   \n",
+       "\n",
+       "                                               job  \\\n",
+       "0  release-openshift-okd-installer-e2e-aws-upgrade   \n",
+       "1  release-openshift-okd-installer-e2e-aws-upgrade   \n",
+       "2  release-openshift-okd-installer-e2e-aws-upgrade   \n",
+       "3  release-openshift-okd-installer-e2e-aws-upgrade   \n",
+       "4  release-openshift-okd-installer-e2e-aws-upgrade   \n",
+       "\n",
+       "                                                test  failure  \n",
+       "0  Application behind service load balancer with ...    False  \n",
+       "1  Application behind service load balancer with ...     True  \n",
+       "2  Application behind service load balancer with ...    False  \n",
+       "3  Application behind service load balancer with ...    False  \n",
+       "4  Application behind service load balancer with ...    False  "
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# this df indicates whether a test was failing or not at a given timestamp\n",
+    "failures_df = pd.DataFrame(\n",
+    "    testgrid_labelwise_encoding(data, 12),\n",
+    "    columns=[\"timestamp\", \"tab\", \"job\", \"test\", \"failure\"],\n",
+    ")\n",
+    "failures_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "bronze-pittsburgh",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tab                           job                                              timestamp          \n",
+       "\"redhat-openshift-informing\"  release-openshift-okd-installer-e2e-aws-upgrade  2020-09-23 22:16:02    1\n",
+       "                                                                               2020-09-24 00:04:39    0\n",
+       "                                                                               2020-09-24 01:57:00    7\n",
+       "                                                                               2020-09-24 03:48:47    0\n",
+       "                                                                               2020-09-24 05:36:09    0\n",
+       "                                                                                                     ..\n",
+       "\"redhat-osde2e-stage-moa\"     osde2e-stage-moa-e2e-upgrade-default-next        2020-10-07 08:01:13    0\n",
+       "                                                                               2020-10-07 16:01:54    0\n",
+       "                                                                               2020-10-08 00:01:28    0\n",
+       "                                                                               2020-10-08 08:02:28    0\n",
+       "                                                                               2020-10-08 16:01:08    0\n",
+       "Name: failure, Length: 32663, dtype: int64"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# each element in this multiindexed series tells how many tests failed at each run/timestamp\n",
+    "num_failures_per_ts = failures_df.groupby([\"tab\", \"job\", \"timestamp\"]).failure.sum()\n",
+    "num_failures_per_ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "humanitarian-london",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tab                           grid                                             timestamp          \n",
+       "\"redhat-openshift-informing\"  release-openshift-okd-installer-e2e-aws-upgrade  2020-09-23 22:16:02    0.000000\n",
+       "                                                                               2020-09-24 00:04:39    1.000000\n",
+       "                                                                               2020-09-24 01:57:00    0.000000\n",
+       "                                                                               2020-09-24 03:48:47    0.857143\n",
+       "                                                                               2020-09-24 05:36:09    0.000000\n",
+       "                                                                                                        ...   \n",
+       "\"redhat-osde2e-stage-moa\"     osde2e-stage-moa-e2e-upgrade-default-next        2020-10-07 08:01:13    0.000000\n",
+       "                                                                               2020-10-07 16:01:54    0.000000\n",
+       "                                                                               2020-10-08 00:01:28    0.000000\n",
+       "                                                                               2020-10-08 08:02:28    0.000000\n",
+       "                                                                               2020-10-08 16:01:08    0.000000\n",
+       "Length: 32663, dtype: float64"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# dividing the above two df's tells us what percent of failing tests got fixed at each timestamp\n",
+    "pct_fixed_per_ts = (num_fixed_per_ts / num_failures_per_ts.shift()).fillna(0)\n",
+    "pct_fixed_per_ts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "informational-growing",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save the metric (takes abot 67 MB in csv data)\n",
+    "file = \"pct_fixed_per_run.csv\"\n",
+    "folder = \"../../../../data/processed/metrics/percent_tests_fixed\"\n",
+    "if not os.path.exists(folder):\n",
+    "    os.makedirs(folder)\n",
+    "\n",
+    "fullpath = os.path.join(folder, file)\n",
+    "pct_fixed_per_ts.to_csv(fullpath, header=False)"
+   ]
+  }
+ ],
+ "metadata": {
+  "finalized": {
+   "timestamp": 1612822647266,
+   "trusted": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes #149 

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

This PR adds a notebook to calculate what percent of failing tests get fixed in each run of the job (as compared to the previous run). 

Marking this notebook as WIP because the calculating function might need some debugging, since we saw some results that do not pass the sanity check.