### PR TITLE
add directory space for ec506 students

### DIFF
--- a/notebooks/data-sources/gcsweb-ci/ec506/ec506.ipynb
+++ b/notebooks/data-sources/gcsweb-ci/ec506/ec506.ipynb
@@ -1,0 +1,34 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# USE THIS DIRECTORY To Write your notbeooks"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "devenv",
+   "language": "python",
+   "name": "devenv"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Related Issues and Dependencies

No dependencies 

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

creates a couple new directories: `/data-sources/gcsweb-ci` to accommodate the log analysis projects we started with the universities.  and `/data-sources/gcsweb-ci/ec506`  specifically for the BU students to use for their class project.  

## Description

<!--- Describe your changes in detail -->
