### PR TITLE
EDA for remaining testgrid metadata fields

### DIFF
--- a/notebooks/data-sources/TestGrid/testgrid_metadata_EDA.ipynb
+++ b/notebooks/data-sources/TestGrid/testgrid_metadata_EDA.ipynb
@@ -68,7 +68,7 @@
    },
    "outputs": [],
    "source": [
-    "response = requests.get(\n",
+    "openshift_testgrid = requests.get(\n",
     "    \"https://testgrid.k8s.io/redhat-openshift-ocp-release-4.2-informing/table? \\\n",
     "    &show-stale-tests=&tab=release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.1-to-4.2\"\n",
     ")"
@@ -85,7 +85,7 @@
    },
    "outputs": [],
    "source": [
-    "response1 = requests.get(\n",
+    "jetstack_testgrid = requests.get(\n",
     "    \"https://testgrid.k8s.io/jetstack-cert-manager-master/table? \\\n",
     "    &show-stale-tests=&tab=ci-cert-manager-bazel\"\n",
     ")"
@@ -95,7 +95,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`response` has all the fields expected by TestGrid's javascript client. It represents a grid of test results, with additional annotations for metadata."
+    "`openshift_testgrid` has all the fields expected by TestGrid's javascript client. It represents a grid of test results, with additional annotations for metadata."
    ]
   },
   {
@@ -162,7 +162,7 @@
     }
    ],
    "source": [
-    "for i in response.json().keys():\n",
+    "for i in openshift_testgrid.json().keys():\n",
     "    print(i)"
    ]
   },
@@ -189,7 +189,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### test-group-name"
+    "## test-group-name"
    ]
   },
   {
@@ -211,7 +211,7 @@
     }
    ],
    "source": [
-    "print(response.json()[\"test-group-name\"])"
+    "print(openshift_testgrid.json()[\"test-group-name\"])"
    ]
   },
   {
@@ -225,7 +225,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### query"
+    "## query"
    ]
   },
   {
@@ -247,7 +247,7 @@
     }
    ],
    "source": [
-    "print(response.json()[\"query\"])"
+    "print(openshift_testgrid.json()[\"query\"])"
    ]
   },
   {
@@ -266,7 +266,7 @@
     }
    },
    "source": [
-    "### status"
+    "## status"
    ]
   },
   {
@@ -283,12 +283,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Served 1207 results in 0.12 seconds\n"
+      "Served 1174 results in 0.27 seconds\n"
      ]
     }
    ],
    "source": [
-    "print(response.json()[\"status\"])"
+    "print(openshift_testgrid.json()[\"status\"])"
    ]
   },
   {
@@ -302,7 +302,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### phase-timer"
+    "## phase-timer"
    ]
   },
   {
@@ -319,12 +319,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'phases': ['config load', 'cache peek (stale)', 'state fetch', 'state decompress', 'state unmarshal', 'table creation', 'table serialize (gob+snappy: 13KiB)', 'table querying'], 'delta': [3.3446e-05, 0.024783251, 0.065446678, 0.000407352, 0.000606137, 0.000143904, 0.001007845, 0.028168015], 'total': 0.120596628}\n"
+      "{'phases': ['config load', 'cache peek (stale)', 'state fetch', 'state decompress', 'state unmarshal', 'table creation', 'table serialize (gob+snappy: 13KiB)', 'table querying'], 'delta': [2.5623e-05, 0.06963295, 0.17168032, 0.000316809, 0.000535445, 0.000140227, 0.000774511, 0.025254081], 'total': 0.268359966}\n"
      ]
     }
    ],
    "source": [
-    "print(response.json()[\"phase-timer\"])"
+    "print(openshift_testgrid.json()[\"phase-timer\"])"
    ]
   },
   {
@@ -343,7 +343,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### cached"
+    "## cached"
    ]
   },
   {
@@ -365,7 +365,7 @@
     }
    ],
    "source": [
-    "print(response.json()[\"cached\"])"
+    "print(openshift_testgrid.json()[\"cached\"])"
    ]
   },
   {
@@ -384,7 +384,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### bugs"
+    "## bugs"
    ]
   },
   {
@@ -406,7 +406,7 @@
     }
    ],
    "source": [
-    "print(response.json()[\"bugs\"])"
+    "print(openshift_testgrid.json()[\"bugs\"])"
    ]
   },
   {
@@ -420,7 +420,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### changelists"
+    "## changelists"
    ]
   },
   {
@@ -437,12 +437,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['1369994168893444096', '1369811862551531520', '1369630643398381568', '1369449096883998720', '1369267681374507008', '1369086139733905408', '1368904775671746560', '1368723410221273088', '1368542014391455744', '1368360542443409408', '1368179004518961152', '1367997486991413248', '1367816194010124288', '1367634626750713856', '1367453420490854400', '1367271859506122752', '1367090290040508416', '1366908795321585664', '1366727302242635776', '1366545773512101888', '1366364084542377984', '1366182730919841792', '1366001409320816640', '1365820080784412672', '1365638694890901504', '1365457253460611072', '1365275795735449600', '1365094202605572096', '1364912643088846848', '1364731000319381504']\n"
+      "['1372535122330390528', '1372353507234942976', '1372171845851156480', '1371990292286148608', '1371808757339656192', '1371627211211149312', '1371445677782994944', '1371264283366658048', '1371082838371209216', '1370901281094242304', '1370719715751628800', '1370538213357129728', '1370358921604108288', '1370302741443776512', '1369994168893444096', '1369811862551531520', '1369630643398381568', '1369449096883998720', '1369267681374507008', '1369086139733905408', '1368904775671746560', '1368723410221273088', '1368542014391455744', '1368360542443409408', '1368179004518961152', '1367997486991413248', '1367816194010124288', '1367634626750713856', '1367453420490854400', '1367271859506122752']\n"
      ]
     }
    ],
    "source": [
-    "print(response.json()[\"changelists\"])"
+    "print(openshift_testgrid.json()[\"changelists\"])"
    ]
   },
   {
@@ -456,7 +456,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### column_ids"
+    "## column_ids"
    ]
   },
   {
@@ -473,12 +473,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['\\ue0001369994168893444096', '\\ue0001369811862551531520', '\\ue0001369630643398381568', '\\ue0001369449096883998720', '\\ue0001369267681374507008', '\\ue0001369086139733905408', '\\ue0001368904775671746560', '\\ue0001368723410221273088', '\\ue0001368542014391455744', '\\ue0001368360542443409408', '\\ue0001368179004518961152', '\\ue0001367997486991413248', '\\ue0001367816194010124288', '\\ue0001367634626750713856', '\\ue0001367453420490854400', '\\ue0001367271859506122752', '\\ue0001367090290040508416', '\\ue0001366908795321585664', '\\ue0001366727302242635776', '\\ue0001366545773512101888', '\\ue0001366364084542377984', '\\ue0001366182730919841792', '\\ue0001366001409320816640', '\\ue0001365820080784412672', '\\ue0001365638694890901504', '\\ue0001365457253460611072', '\\ue0001365275795735449600', '\\ue0001365094202605572096', '\\ue0001364912643088846848', '\\ue0001364731000319381504']\n"
+      "['\\ue0001372535122330390528', '\\ue0001372353507234942976', '\\ue0001372171845851156480', '\\ue0001371990292286148608', '\\ue0001371808757339656192', '\\ue0001371627211211149312', '\\ue0001371445677782994944', '\\ue0001371264283366658048', '\\ue0001371082838371209216', '\\ue0001370901281094242304', '\\ue0001370719715751628800', '\\ue0001370538213357129728', '\\ue0001370358921604108288', '\\ue0001370302741443776512', '\\ue0001369994168893444096', '\\ue0001369811862551531520', '\\ue0001369630643398381568', '\\ue0001369449096883998720', '\\ue0001369267681374507008', '\\ue0001369086139733905408', '\\ue0001368904775671746560', '\\ue0001368723410221273088', '\\ue0001368542014391455744', '\\ue0001368360542443409408', '\\ue0001368179004518961152', '\\ue0001367997486991413248', '\\ue0001367816194010124288', '\\ue0001367634626750713856', '\\ue0001367453420490854400', '\\ue0001367271859506122752']\n"
      ]
     }
    ],
    "source": [
-    "print(response.json()[\"column_ids\"])"
+    "print(openshift_testgrid.json()[\"column_ids\"])"
    ]
   },
   {
@@ -503,7 +503,7 @@
     }
    ],
    "source": [
-    "len(response.json()[\"column_ids\"])"
+    "len(openshift_testgrid.json()[\"column_ids\"])"
    ]
   },
   {
@@ -569,7 +569,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### custom-columns"
+    "## custom-columns"
    ]
   },
   {
@@ -586,12 +586,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[['missing', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1'], ['missing', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '']]\n"
+      "[['1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', 'missing', '1', 'missing', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1'], ['', '', '', '', '', '', '', '', '', '', '', '', 'missing', '', 'missing', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '']]\n"
      ]
     }
    ],
    "source": [
-    "print(response.json()[\"custom-columns\"])"
+    "print(openshift_testgrid.json()[\"custom-columns\"])"
    ]
   },
   {
@@ -608,12 +608,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[['f40ffc87c', 'f40ffc87c', 'f40ffc87c', 'f40ffc87c', '9f343ec58', '9f343ec58', '9f343ec58', '9f343ec58', '9f343ec58', '9f343ec58', '9f343ec58', '9f343ec58', '9f343ec58', '9f343ec58', '9f343ec58', '9f343ec58', 'c01603dd3', 'c2634d353', 'c2634d353', 'c2634d353', 'c2634d353', 'c2634d353', 'c2634d353', 'c2634d353', 'c2634d353', 'c2634d353', 'c2634d353', 'c2634d353', 'c2634d353', 'c2634d353', 'c2634d353', 'c2634d353', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '75a46ff90', 'deb55110a', 'deb55110a', 'deb55110a', 'deb55110a', 'deb55110a', 'deb55110a', 'deb55110a', 'deb55110a', 'deb55110a', '28fc97699', '28fc97699', '28fc97699', '28fc97699', 'eced645c8', 'eced645c8', 'eced645c8', 'eced645c8', 'eced645c8', 'eced645c8', 'eced645c8', 'eced645c8', 'eced645c8', 'eced645c8', 'eced645c8', 'eced645c8', 'eced645c8', 'eced645c8', 'eced645c8', 'eced645c8', 'eced645c8', 'eced645c8', 'eced645c8', 'eced645c8', 'eced645c8', 'eced645c8', 'eced645c8', 'eced645c8', 'a9c672e90', 'a9c672e90', 'a9c672e90', 'a9c672e90', 'a9c672e90', 'a9c672e90', 'a9c672e90', 'a9c672e90', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1', '95f8d53e1'], ['missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing']]\n"
+      "[['442d7dbc0', '442d7dbc0', '442d7dbc0', '442d7dbc0', '442d7dbc0', '442d7dbc0', '442d7dbc0', '442d7dbc0', '442d7dbc0', '442d7dbc0', '442d7dbc0', '442d7dbc0', '442d7dbc0', '442d7dbc0', '442d7dbc0', '433cc2fa0', '433cc2fa0', 'fedea03a1', 'fedea03a1', 'fedea03a1', 'fedea03a1', 'fedea03a1', 'fedea03a1', 'fedea03a1', 'fedea03a1', 'fedea03a1', 'fedea03a1', 'fedea03a1', 'fedea03a1', 'fedea03a1', 'fedea03a1', 'fedea03a1', 'fedea03a1', 'fedea03a1', 'fedea03a1', 'fedea03a1', 'fedea03a1', '03b3e2f20', '38ebe359a', '65a7a880f', '65a7a880f', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', '51340d0c8', 'f40ffc87c', 'f40ffc87c', 'f40ffc87c', 'f40ffc87c', '9f343ec58', '9f343ec58', '9f343ec58', '9f343ec58', '9f343ec58', '9f343ec58', '9f343ec58', '9f343ec58', '9f343ec58', '9f343ec58', '9f343ec58', '9f343ec58', 'c01603dd3', 'c2634d353', 'c2634d353', 'c2634d353', 'c2634d353', 'c2634d353', 'c2634d353', 'c2634d353', 'c2634d353', 'c2634d353', 'c2634d353', 'c2634d353', 'c2634d353', 'c2634d353', 'c2634d353', 'c2634d353', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '07964edea', '75a46ff90', 'deb55110a', 'deb55110a', 'deb55110a', 'deb55110a', 'deb55110a', 'deb55110a', 'deb55110a', 'deb55110a', 'deb55110a', '28fc97699', '28fc97699', '28fc97699', '28fc97699', 'eced645c8', 'eced645c8', 'eced645c8', 'eced645c8', 'eced645c8', 'eced645c8', 'eced645c8'], ['missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing', 'missing']]\n"
      ]
     }
    ],
    "source": [
-    "print(response1.json()[\"custom-columns\"])"
+    "print(jetstack_testgrid.json()[\"custom-columns\"])"
    ]
   },
   {
@@ -673,14 +673,14 @@
     }
    ],
    "source": [
-    "len(response.json()[\"custom-columns\"][0])"
+    "len(openshift_testgrid.json()[\"custom-columns\"][0])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### column-header-names"
+    "## column-header-names"
    ]
   },
   {
@@ -702,7 +702,7 @@
     }
    ],
    "source": [
-    "print(response.json()[\"column-header-names\"])"
+    "print(openshift_testgrid.json()[\"column-header-names\"])"
    ]
   },
   {
@@ -775,7 +775,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### groups"
+    "## groups"
    ]
   },
   {
@@ -797,7 +797,7 @@
     }
    ],
    "source": [
-    "print(response1.json()[\"groups\"])"
+    "print(jetstack_testgrid.json()[\"groups\"])"
    ]
   },
   {
@@ -816,7 +816,7 @@
     }
    },
    "source": [
-    "### metrics"
+    "## metrics"
    ]
   },
   {
@@ -838,7 +838,7 @@
     }
    ],
    "source": [
-    "print(response1.json()[\"metrics\"])"
+    "print(jetstack_testgrid.json()[\"metrics\"])"
    ]
   },
   {
@@ -878,7 +878,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### row_ids"
+    "## row_ids"
    ]
   },
   {
@@ -890,12 +890,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['Overall', 'Pod', 'Operator results.operator conditions authentication', 'Operator results.operator conditions cloud-credential', 'Operator results.operator conditions monitoring', 'Operator results.operator conditions network', 'Operator results.operator conditions openshift-samples', 'openshift-tests.Monitor cluster while tests execute', 'openshift-tests.[Disruptive] Cluster upgrade should maintain a functioning cluster [Feature:ClusterUpgrade] [Suite:openshift] [Serial]', 'operator.Run template e2e-aws-upgrade - e2e-aws-upgrade container test', 'Operator results.operator conditions operator-lifecycle-manager-packageserver', 'Operator results.operator conditions service-ca', 'Operator results.operator conditions image-registry', 'Operator results.operator conditions dns', 'Operator results.operator conditions machine-config', 'Operator results.operator conditions console', 'Operator results.operator conditions openshift-apiserver', 'operator.Run template e2e-aws-upgrade - e2e-aws-upgrade container setup', 'Cluster upgrade.[sig-apps] daemonset-upgrade', 'Cluster upgrade.[sig-apps] deployment-upgrade', 'Cluster upgrade.[sig-apps] job-upgrade', 'Cluster upgrade.[sig-apps] replicaset-upgrade', 'Cluster upgrade.[sig-apps] statefulset-upgrade', 'Cluster upgrade.[sig-storage] [sig-api-machinery] configmap-upgrade', 'Cluster upgrade.[sig-storage] [sig-api-machinery] secret-upgrade', 'Cluster upgrade.service-upgrade', 'Cluster upgrade.upgrade', 'Operator results.operator conditions cluster-autoscaler', 'Operator results.operator conditions ingress', 'Operator results.operator conditions insights', 'Operator results.operator conditions kube-apiserver', 'Operator results.operator conditions kube-controller-manager', 'Operator results.operator conditions kube-scheduler', 'Operator results.operator conditions machine-api', 'Operator results.operator conditions marketplace', 'Operator results.operator conditions node-tuning', 'Operator results.operator conditions openshift-controller-manager', 'Operator results.operator conditions operator-lifecycle-manager', 'Operator results.operator conditions operator-lifecycle-manager-catalog', 'Operator results.operator conditions service-catalog-apiserver', 'Operator results.operator conditions service-catalog-controller-manager', 'Operator results.operator conditions storage', 'Symptom Detection.Bug 1812261: iptables is segfaulting', 'Symptom Detection.Infrastructure - AWS simulate policy rate-limit', 'Symptom Detection.Infrastructure - GCP quota exceeded (route to forum-gcp)', 'Symptom Detection.Node process segfaulted', 'Symptom Detection.Undiagnosed panic detected in pod', 'operator.All images are built and tagged into stable', 'operator.Find all of the input images from ocp/4.1:${component} and tag them into the output image stream', 'operator.Import the release payload \"initial\" from an external source', 'operator.Import the release payload \"latest\" from an external source', 'operator.Run template e2e-aws-upgrade - e2e-aws-upgrade container teardown']\n"
+      "['Overall', 'Operator results.operator conditions authentication', 'Operator results.operator conditions cloud-credential', 'Operator results.operator conditions monitoring', 'Operator results.operator conditions network', 'Operator results.operator conditions openshift-samples', 'openshift-tests.Monitor cluster while tests execute', 'openshift-tests.[Disruptive] Cluster upgrade should maintain a functioning cluster [Feature:ClusterUpgrade] [Suite:openshift] [Serial]', 'operator.Run template e2e-aws-upgrade - e2e-aws-upgrade container test', 'Operator results.operator conditions dns', 'Operator results.operator conditions operator-lifecycle-manager-packageserver', 'Operator results.operator conditions console', 'Operator results.operator conditions service-ca', 'Operator results.operator conditions image-registry', 'Pod', 'Operator results.operator conditions machine-config', 'Operator results.operator conditions cluster-autoscaler', 'Operator results.operator conditions ingress', 'Operator results.operator conditions insights', 'Operator results.operator conditions kube-apiserver', 'Operator results.operator conditions kube-controller-manager', 'Operator results.operator conditions kube-scheduler', 'Operator results.operator conditions machine-api', 'Operator results.operator conditions marketplace', 'Operator results.operator conditions node-tuning', 'Operator results.operator conditions openshift-apiserver', 'Operator results.operator conditions openshift-controller-manager', 'Operator results.operator conditions operator-lifecycle-manager', 'Operator results.operator conditions operator-lifecycle-manager-catalog', 'Operator results.operator conditions service-catalog-apiserver', 'Operator results.operator conditions service-catalog-controller-manager', 'Operator results.operator conditions storage', 'Symptom Detection.Bug 1812261: iptables is segfaulting', 'Symptom Detection.Infrastructure - AWS simulate policy rate-limit', 'Symptom Detection.Infrastructure - GCP quota exceeded (route to forum-gcp)', 'Symptom Detection.Node process segfaulted', 'Symptom Detection.Undiagnosed panic detected in pod', 'operator.All images are built and tagged into stable', 'operator.Find all of the input images from ocp/4.1:${component} and tag them into the output image stream', 'operator.Import the release payload \"initial\" from an external source', 'operator.Import the release payload \"latest\" from an external source', 'operator.Run template e2e-aws-upgrade - e2e-aws-upgrade container setup', 'operator.Run template e2e-aws-upgrade - e2e-aws-upgrade container teardown']\n"
      ]
     }
    ],
    "source": [
-    "print(response.json()[\"row_ids\"])"
+    "print(openshift_testgrid.json()[\"row_ids\"])"
    ]
   },
   {
@@ -913,7 +913,7 @@
     {
      "data": {
       "text/plain": [
-       "52"
+       "43"
       ]
      },
      "execution_count": 27,
@@ -922,14 +922,14 @@
     }
    ],
    "source": [
-    "len(response.json()[\"row_ids\"])"
+    "len(openshift_testgrid.json()[\"row_ids\"])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We see that `52` tests were run for the job `release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.1-to-4.2` in the dashboard `redhat-openshift-ocp-release-4.2-informing`"
+    "We see that as of right now, `43` tests were run for the job `release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.1-to-4.2` in the dashboard `redhat-openshift-ocp-release-4.2-informing`"
    ]
   },
   {
@@ -941,12 +941,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['Pod', 'Overall', '//cmd/ctl/pkg/create/certificaterequest:go_default_test', '//cmd/ctl/pkg/inspect/secret:go_default_test', '//cmd/ctl/pkg/renew:go_default_test', '//cmd/ctl/pkg/status/certificate:go_default_test', '//hack:verify-bazel', '//hack:verify-boilerplate', '//hack:verify-codegen', '//hack:verify-crds', '//hack:verify-errexit', '//hack:verify-gofmt', '//pkg/acme/accounts:go_default_test', '//pkg/acme/util:go_default_test', '//pkg/api/util:go_default_test', '//pkg/controller/acmechallenges/scheduler:go_default_test', '//pkg/controller/acmechallenges:go_default_test', '//pkg/controller/acmeorders/selectors:go_default_test', '//pkg/controller/acmeorders:go_default_test', '//pkg/controller/certificaterequests/acme:go_default_test', '//pkg/controller/certificaterequests/ca:go_default_test', '//pkg/controller/certificaterequests/selfsigned:go_default_test', '//pkg/controller/certificaterequests/util:go_default_test', '//pkg/controller/certificaterequests/vault:go_default_test', '//pkg/controller/certificaterequests/venafi:go_default_test', '//pkg/controller/certificaterequests:go_default_test', '//pkg/controller/certificates/internal/secretsmanager:go_default_test', '//pkg/controller/certificates/issuing:go_default_test', '//pkg/controller/certificates/keymanager:go_default_test', '//pkg/controller/certificates/readiness:go_default_test', '//pkg/controller/certificates/requestmanager:go_default_test', '//pkg/controller/certificates/trigger/policies:go_default_test', '//pkg/controller/certificates/trigger:go_default_test', '//pkg/controller/certificates:go_default_test', '//pkg/controller/clusterissuers:go_default_test', '//pkg/controller/ingress-shim:go_default_test', '//pkg/controller/issuers:go_default_test', '//pkg/internal/api/validation:go_default_test', '//pkg/internal/apis/acme/install:go_default_test', '//pkg/internal/apis/acme/validation:go_default_test', '//pkg/internal/apis/certmanager/install:go_default_test', '//pkg/internal/apis/certmanager/validation/util:go_default_test', '//pkg/internal/apis/certmanager/validation:go_default_test', '//pkg/internal/apis/meta/install:go_default_test', '//pkg/internal/vault:go_default_test', '//pkg/issuer/acme/dns/acmedns:go_default_test', '//pkg/issuer/acme/dns/akamai:go_default_test', '//pkg/issuer/acme/dns/azuredns:go_default_test', '//pkg/issuer/acme/dns/clouddns:go_default_test', '//pkg/issuer/acme/dns/cloudflare:go_default_test', '//pkg/issuer/acme/dns/digitalocean:go_default_test', '//pkg/issuer/acme/dns/rfc2136:go_default_test', '//pkg/issuer/acme/dns/route53:go_default_test', '//pkg/issuer/acme/dns/util:go_default_test', '//pkg/issuer/acme/dns:go_default_test', '//pkg/issuer/acme/http:go_default_test', '//pkg/issuer/venafi/client:go_default_test', '//pkg/issuer/venafi:go_default_test', '//pkg/issuer:go_default_test', '//pkg/metrics:go_default_test', '//pkg/scheduler:go_default_test', '//pkg/util/pki:go_default_test', '//pkg/util/predicate:go_default_test', '//pkg/util:go_default_test', '//pkg/webhook/authority:go_default_test', '//pkg/webhook/handlers/testdata/apis/testgroup/install:go_default_test', '//pkg/webhook/handlers/testdata/apis/testgroup/validation:go_default_test', '//pkg/webhook/handlers:go_default_test', '//pkg/webhook/server/tls:go_default_test', '//pkg/webhook/server:go_default_test', '//test/integration/certificates:go_default_test', '//test/integration/conversion:go_default_test', '//test/integration/ctl:go_default_test', '//test/integration/validation:go_default_test', '//test/integration/webhook:go_default_test', '//tools/cobra:go_default_test']\n"
+      "['Pod', 'Overall', '//cmd/ctl/pkg/create/certificaterequest:go_default_test', '//cmd/ctl/pkg/inspect/secret:go_default_test', '//cmd/ctl/pkg/renew:go_default_test', '//cmd/ctl/pkg/status/certificate:go_default_test', '//hack:verify-bazel', '//hack:verify-boilerplate', '//hack:verify-codegen', '//hack:verify-crds', '//hack:verify-errexit', '//hack:verify-gofmt', '//pkg/acme/accounts:go_default_test', '//pkg/acme/util:go_default_test', '//pkg/api/util:go_default_test', '//pkg/controller/acmechallenges/scheduler:go_default_test', '//pkg/controller/acmechallenges:go_default_test', '//pkg/controller/acmeorders/selectors:go_default_test', '//pkg/controller/acmeorders:go_default_test', '//pkg/controller/certificaterequests/acme:go_default_test', '//pkg/controller/certificaterequests/approver:go_default_test', '//pkg/controller/certificaterequests/ca:go_default_test', '//pkg/controller/certificaterequests/selfsigned:go_default_test', '//pkg/controller/certificaterequests/util:go_default_test', '//pkg/controller/certificaterequests/vault:go_default_test', '//pkg/controller/certificaterequests/venafi:go_default_test', '//pkg/controller/certificaterequests:go_default_test', '//pkg/controller/certificates/internal/secretsmanager:go_default_test', '//pkg/controller/certificates/issuing:go_default_test', '//pkg/controller/certificates/keymanager:go_default_test', '//pkg/controller/certificates/readiness:go_default_test', '//pkg/controller/certificates/requestmanager:go_default_test', '//pkg/controller/certificates/trigger/policies:go_default_test', '//pkg/controller/certificates/trigger:go_default_test', '//pkg/controller/certificates:go_default_test', '//pkg/controller/clusterissuers:go_default_test', '//pkg/controller/ingress-shim:go_default_test', '//pkg/controller/issuers:go_default_test', '//pkg/internal/api/mutation:go_default_test', '//pkg/internal/api/validation:go_default_test', '//pkg/internal/apis/acme/install:go_default_test', '//pkg/internal/apis/acme/validation:go_default_test', '//pkg/internal/apis/certmanager/identity/certificaterequests:go_default_test', '//pkg/internal/apis/certmanager/install:go_default_test', '//pkg/internal/apis/certmanager/validation/util:go_default_test', '//pkg/internal/apis/certmanager/validation:go_default_test', '//pkg/internal/apis/meta/install:go_default_test', '//pkg/internal/vault:go_default_test', '//pkg/issuer/acme/dns/acmedns:go_default_test', '//pkg/issuer/acme/dns/akamai:go_default_test', '//pkg/issuer/acme/dns/azuredns:go_default_test', '//pkg/issuer/acme/dns/clouddns:go_default_test', '//pkg/issuer/acme/dns/cloudflare:go_default_test', '//pkg/issuer/acme/dns/digitalocean:go_default_test', '//pkg/issuer/acme/dns/rfc2136:go_default_test', '//pkg/issuer/acme/dns/route53:go_default_test', '//pkg/issuer/acme/dns/util:go_default_test', '//pkg/issuer/acme/dns:go_default_test', '//pkg/issuer/acme/http:go_default_test', '//pkg/issuer/venafi/client:go_default_test', '//pkg/issuer/venafi:go_default_test', '//pkg/issuer:go_default_test', '//pkg/metrics:go_default_test', '//pkg/scheduler:go_default_test', '//pkg/util/pki:go_default_test', '//pkg/util/predicate:go_default_test', '//pkg/util:go_default_test', '//pkg/webhook/authority:go_default_test', '//pkg/webhook/handlers/testdata/apis/testgroup/install:go_default_test', '//pkg/webhook/handlers/testdata/apis/testgroup/validation:go_default_test', '//pkg/webhook/handlers:go_default_test', '//pkg/webhook/server/tls:go_default_test', '//pkg/webhook/server:go_default_test', '//test/integration/certificates:go_default_test', '//test/integration/conversion:go_default_test', '//test/integration/ctl:go_default_test', '//test/integration/validation:go_default_test', '//test/integration/webhook:go_default_test', '//tools/cobra:go_default_test']\n"
      ]
     }
    ],
    "source": [
-    "print(response1.json()[\"row_ids\"])"
+    "print(jetstack_testgrid.json()[\"row_ids\"])"
    ]
   },
   {
@@ -957,7 +957,7 @@
     {
      "data": {
       "text/plain": [
-       "76"
+       "79"
       ]
      },
      "execution_count": 29,
@@ -966,7 +966,7 @@
     }
    ],
    "source": [
-    "len(response1.json()[\"row_ids\"])"
+    "len(jetstack_testgrid.json()[\"row_ids\"])"
    ]
   },
   {
@@ -980,7 +980,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### timestamps"
+    "## timestamps"
    ]
   },
   {
@@ -992,12 +992,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[1615467683000, 1615423576000, 1615380370000, 1615337085000, 1615293832000, 1615250550000, 1615207308000, 1615164068000, 1615120820000, 1615077555000, 1615034271000, 1614990999000, 1614947770000, 1614904482000, 1614861279000, 1614817991000, 1614774702000, 1614731430000, 1614688159000, 1614644879000, 1614601573000, 1614558326000, 1614515097000, 1614471864000, 1614428617000, 1614385358000, 1614342104000, 1614298805000, 1614255516000, 1614212210000]\n"
+      "[1616072850000, 1616029551000, 1615986240000, 1615942953000, 1615899672000, 1615856389000, 1615813107000, 1615769859000, 1615726599000, 1615683312000, 1615640024000, 1615596750000, 1615554026000, 1615540610000, 1615467683000, 1615423576000, 1615380370000, 1615337085000, 1615293832000, 1615250550000, 1615207308000, 1615164068000, 1615120820000, 1615077555000, 1615034271000, 1614990999000, 1614947770000, 1614904482000, 1614861279000, 1614817991000]\n"
      ]
     }
    ],
    "source": [
-    "print(response.json()[\"timestamps\"])"
+    "print(openshift_testgrid.json()[\"timestamps\"])"
    ]
   },
   {
@@ -1024,7 +1024,7 @@
     }
    ],
    "source": [
-    "len(response.json()[\"timestamps\"])"
+    "len(openshift_testgrid.json()[\"timestamps\"])"
    ]
   },
   {
@@ -1035,7 +1035,22 @@
     {
      "data": {
       "text/plain": [
-       "['11-03-21',\n",
+       "['18-03-21',\n",
+       " '18-03-21',\n",
+       " '17-03-21',\n",
+       " '17-03-21',\n",
+       " '16-03-21',\n",
+       " '16-03-21',\n",
+       " '15-03-21',\n",
+       " '15-03-21',\n",
+       " '14-03-21',\n",
+       " '14-03-21',\n",
+       " '13-03-21',\n",
+       " '13-03-21',\n",
+       " '12-03-21',\n",
+       " '12-03-21',\n",
+       " '11-03-21',\n",
+       " '11-03-21',\n",
        " '10-03-21',\n",
        " '10-03-21',\n",
        " '09-03-21',\n",
@@ -1049,22 +1064,7 @@
        " '05-03-21',\n",
        " '05-03-21',\n",
        " '04-03-21',\n",
-       " '04-03-21',\n",
-       " '03-03-21',\n",
-       " '03-03-21',\n",
-       " '02-03-21',\n",
-       " '02-03-21',\n",
-       " '01-03-21',\n",
-       " '01-03-21',\n",
-       " '28-02-21',\n",
-       " '28-02-21',\n",
-       " '27-02-21',\n",
-       " '27-02-21',\n",
-       " '26-02-21',\n",
-       " '26-02-21',\n",
-       " '25-02-21',\n",
-       " '25-02-21',\n",
-       " '24-02-21']"
+       " '04-03-21']"
       ]
      },
      "execution_count": 32,
@@ -1073,7 +1073,7 @@
     }
    ],
    "source": [
-    "t1 = response.json()[\"timestamps\"]\n",
+    "t1 = openshift_testgrid.json()[\"timestamps\"]\n",
     "dates = [dt.datetime.fromtimestamp(item / 1000).strftime(\"%d-%m-%y\") for item in t1]\n",
     "dates"
    ]
@@ -1094,12 +1094,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[1615489068000, 1615481837000, 1615474638000, 1615467437000, 1615460238000, 1615453038000, 1615438637000, 1615431437000, 1615424177000, 1615359061000, 1615351801000, 1615344541000, 1615337283000, 1615330024000, 1615322760000, 1615315502000, 1615308246000, 1615300982000, 1615293730000, 1615286578000, 1615279310000, 1615272050000, 1615264852000, 1615257591000, 1615250331000, 1615243131000, 1615235932000, 1615228732000, 1615221531000, 1615214272000, 1615207072000, 1615199810000, 1615192620000, 1615185361000, 1615178103000, 1615170840000, 1615163580000, 1615156321000, 1615149060000, 1615141800000, 1615134572000, 1615127312000, 1615120051000, 1615112789000, 1615105569000, 1615098308000, 1615091050000, 1615083792000, 1615076528000, 1615069269000, 1615062029000, 1615054771000, 1615047514000, 1615040251000, 1615032990000, 1615025731000, 1615018470000, 1615011211000, 1615003951000, 1614996691000, 1614989431000, 1614982172000, 1614974924000, 1614967665000, 1614960398000, 1614953138000, 1614945878000, 1614938621000, 1614931358000, 1614924097000, 1614916838000, 1614909578000, 1614902318000, 1614895059000, 1614887798000, 1614880537000, 1614873315000, 1614866057000, 1614858866000, 1614851658000, 1614844455000, 1614837262000, 1614830002000, 1614822741000, 1614815482000, 1614808225000, 1614800991000, 1614793790000, 1614786590000, 1614779364000, 1614772092000, 1614764834000, 1614757572000, 1614750320000, 1614743118000, 1614735919000, 1614728719000, 1614721520000, 1614714320000, 1614707119000, 1614699859000, 1614692610000, 1614685346000, 1614678086000, 1614670829000, 1614663565000, 1614656366000, 1614649165000, 1614641905000, 1614634645000, 1614627385000, 1614620125000, 1614612865000, 1614605605000, 1614598350000, 1614591113000, 1614583853000, 1614576657000, 1614569452000, 1614562252000, 1614555030000, 1614547937000, 1614540630000, 1614533429000, 1614526218000, 1614519013000, 1614511756000, 1614504553000, 1614497336000, 1614490141000, 1614482938000, 1614475736000, 1614468535000, 1614461276000, 1614454076000, 1614446815000, 1614439559000, 1614432300000, 1614425036000, 1614417845000, 1614410647000, 1614403445000, 1614396247000, 1614388986000, 1614381727000, 1614374467000, 1614367211000, 1614359947000, 1614352686000, 1614345426000, 1614338166000, 1614330921000, 1614323663000, 1614316402000, 1614309143000, 1614301882000, 1614294623000, 1614287366000, 1614280102000, 1614272842000, 1614265584000, 1614258324000, 1614251062000, 1614243859000, 1614236600000, 1614229399000, 1614222199000, 1614214942000, 1614207679000, 1614200420000]\n"
+      "[1616097568000, 1616090308000, 1616083050000, 1616075827000, 1616068570000, 1616061307000, 1616054049000, 1616046787000, 1616039527000, 1616032268000, 1616025068000, 1616017807000, 1616010576000, 1616003321000, 1615996053000, 1615988868000, 1615981605000, 1615974348000, 1615967085000, 1615959825000, 1615952564000, 1615945305000, 1615938046000, 1615930784000, 1615923526000, 1615916264000, 1615909010000, 1615901797000, 1615894537000, 1615887337000, 1615880137000, 1615872938000, 1615865738000, 1615858540000, 1615851338000, 1615844077000, 1615836878000, 1615829617000, 1615822359000, 1615815127000, 1615807930000, 1615800668000, 1615793866000, 1615786147000, 1615778888000, 1615771629000, 1615764369000, 1615757109000, 1615749850000, 1615742665000, 1615735466000, 1615728265000, 1615721004000, 1615713745000, 1615706485000, 1615699225000, 1615691964000, 1615684704000, 1615677444000, 1615670184000, 1615662924000, 1615655660000, 1615648448000, 1615641189000, 1615633928000, 1615626668000, 1615619409000, 1615612149000, 1615604888000, 1615597628000, 1615590369000, 1615583108000, 1615575848000, 1615568632000, 1615561428000, 1615554229000, 1615547027000, 1615539827000, 1615532568000, 1615525368000, 1615518107000, 1615510847000, 1615503587000, 1615496327000, 1615489068000, 1615481837000, 1615474638000, 1615467437000, 1615460238000, 1615453038000, 1615438637000, 1615431437000, 1615424177000, 1615359061000, 1615351801000, 1615344541000, 1615337283000, 1615330024000, 1615322760000, 1615315502000, 1615308246000, 1615300982000, 1615293730000, 1615286578000, 1615279310000, 1615272050000, 1615264852000, 1615257591000, 1615250331000, 1615243131000, 1615235932000, 1615228732000, 1615221531000, 1615214272000, 1615207072000, 1615199810000, 1615192620000, 1615185361000, 1615178103000, 1615170840000, 1615163580000, 1615156321000, 1615149060000, 1615141800000, 1615134572000, 1615127312000, 1615120051000, 1615112789000, 1615105569000, 1615098308000, 1615091050000, 1615083792000, 1615076528000, 1615069269000, 1615062029000, 1615054771000, 1615047514000, 1615040251000, 1615032990000, 1615025731000, 1615018470000, 1615011211000, 1615003951000, 1614996691000, 1614989431000, 1614982172000, 1614974924000, 1614967665000, 1614960398000, 1614953138000, 1614945878000, 1614938621000, 1614931358000, 1614924097000, 1614916838000, 1614909578000, 1614902318000, 1614895059000, 1614887798000, 1614880537000, 1614873315000, 1614866057000, 1614858866000, 1614851658000, 1614844455000, 1614837262000, 1614830002000, 1614822741000, 1614815482000, 1614808225000]\n"
      ]
     }
    ],
    "source": [
-    "print(response1.json()[\"timestamps\"])"
+    "print(jetstack_testgrid.json()[\"timestamps\"])"
    ]
   },
   {
@@ -1119,14 +1119,14 @@
     }
    ],
    "source": [
-    "len(response1.json()[\"timestamps\"])"
+    "len(jetstack_testgrid.json()[\"timestamps\"])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### clusters"
+    "## clusters"
    ]
   },
   {
@@ -1143,7 +1143,7 @@
     }
    ],
    "source": [
-    "print(response.json()[\"clusters\"])"
+    "print(openshift_testgrid.json()[\"clusters\"])"
    ]
   },
   {
@@ -1160,7 +1160,7 @@
     }
    ],
    "source": [
-    "print(response1.json()[\"clusters\"])"
+    "print(jetstack_testgrid.json()[\"clusters\"])"
    ]
   },
   {
@@ -1195,7 +1195,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### test_id_map"
+    "## test_id_map"
    ]
   },
   {
@@ -1212,7 +1212,7 @@
     }
    ],
    "source": [
-    "print(response.json()[\"test_id_map\"])"
+    "print(openshift_testgrid.json()[\"test_id_map\"])"
    ]
   },
   {
@@ -1229,7 +1229,7 @@
     }
    ],
    "source": [
-    "print(response1.json()[\"test_id_map\"])"
+    "print(jetstack_testgrid.json()[\"test_id_map\"])"
    ]
   },
   {
@@ -1243,7 +1243,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### test-metadata"
+    "## test-metadata"
    ]
   },
   {
@@ -1260,7 +1260,7 @@
     }
    ],
    "source": [
-    "print(response.json()[\"test-metadata\"])"
+    "print(openshift_testgrid.json()[\"test-metadata\"])"
    ]
   },
   {
@@ -1277,14 +1277,14 @@
     }
    ],
    "source": [
-    "print(response1.json()[\"test-metadata\"])"
+    "print(jetstack_testgrid.json()[\"test-metadata\"])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### stale-test-threshold"
+    "## stale-test-threshold"
    ]
   },
   {
@@ -1301,7 +1301,7 @@
     }
    ],
    "source": [
-    "print(response.json()[\"stale-test-threshold\"])"
+    "print(openshift_testgrid.json()[\"stale-test-threshold\"])"
    ]
   },
   {
@@ -1318,21 +1318,21 @@
     }
    ],
    "source": [
-    "print(response1.json()[\"stale-test-threshold\"])"
+    "print(jetstack_testgrid.json()[\"stale-test-threshold\"])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`stale-test-threshold` probably indicates the threshold for the number of tests that can be stale for a particular job. For both the jobs in this example, 10 is the maximum number of tests that can be \"stale\"."
+    "`stale-test-threshold` probably means the number of times a test is _not_ run for a particular job, before it gets labeled as \"stale\" and hidden in the UI. For both the jobs in this example, this threshold is 10."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### num-stale-tests"
+    "## num-stale-tests"
    ]
   },
   {
@@ -1344,19 +1344,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "9\n"
+      "0\n"
      ]
     }
    ],
    "source": [
-    "print(response.json()[\"num-stale-tests\"])"
+    "print(openshift_testgrid.json()[\"num-stale-tests\"])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We see that for job`release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.1-to-4.2` in the dashboard `redhat-openshift-ocp-release-4.2-informing`, the number of stale tests is `9` which is below the defined threshold of 10."
+    "We see that for job`release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.1-to-4.2` in the dashboard `redhat-openshift-ocp-release-4.2-informing`, the number of stale tests is `0`."
    ]
   },
   {
@@ -1373,21 +1373,21 @@
     }
    ],
    "source": [
-    "print(response1.json()[\"num-stale-tests\"])"
+    "print(jetstack_testgrid.json()[\"num-stale-tests\"])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Similary, for the job `ci-cert-manager-bazel` in dashboard `jetstack-cert-manager-master`, the number of stale tests were `0` which is well below the defined threshold of 10."
+    "Similary, for the job `ci-cert-manager-bazel` in dashboard `jetstack-cert-manager-master`, the number of stale tests were `0`."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### add-tabular-name-option"
+    "## add-tabular-name-option"
    ]
   },
   {
@@ -1404,7 +1404,7 @@
     }
    ],
    "source": [
-    "print(response.json()[\"add-tabular-names-option\"])"
+    "print(openshift_testgrid.json()[\"add-tabular-names-option\"])"
    ]
   },
   {
@@ -1421,7 +1421,7 @@
     }
    ],
    "source": [
-    "print(response1.json()[\"add-tabular-names-option\"])"
+    "print(jetstack_testgrid.json()[\"add-tabular-names-option\"])"
    ]
   },
   {
@@ -1435,7 +1435,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### show-tabular-names"
+    "## show-tabular-names"
    ]
   },
   {
@@ -1452,7 +1452,7 @@
     }
    ],
    "source": [
-    "print(response.json()[\"show-tabular-names\"])"
+    "print(openshift_testgrid.json()[\"show-tabular-names\"])"
    ]
   },
   {
@@ -1469,7 +1469,7 @@
     }
    ],
    "source": [
-    "print(response1.json()[\"show-tabular-names\"])"
+    "print(jetstack_testgrid.json()[\"show-tabular-names\"])"
    ]
   },
   {
@@ -1483,7 +1483,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### description"
+    "## description"
    ]
   },
   {
@@ -1500,7 +1500,7 @@
     }
    ],
    "source": [
-    "print(response.json()[\"description\"])"
+    "print(openshift_testgrid.json()[\"description\"])"
    ]
   },
   {
@@ -1517,7 +1517,7 @@
     }
    ],
    "source": [
-    "print(response1.json()[\"description\"])"
+    "print(jetstack_testgrid.json()[\"description\"])"
    ]
   },
   {
@@ -1531,7 +1531,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### bug-component"
+    "## bug-component"
    ]
   },
   {
@@ -1548,7 +1548,7 @@
     }
    ],
    "source": [
-    "print(response.json()[\"bug-component\"])"
+    "print(openshift_testgrid.json()[\"bug-component\"])"
    ]
   },
   {
@@ -1565,7 +1565,7 @@
     }
    ],
    "source": [
-    "print(response1.json()[\"bug-component\"])"
+    "print(jetstack_testgrid.json()[\"bug-component\"])"
    ]
   },
   {
@@ -1579,7 +1579,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### code-search-path"
+    "## code-search-path"
    ]
   },
   {
@@ -1596,7 +1596,7 @@
     }
    ],
    "source": [
-    "print(response.json()[\"code-search-path\"])"
+    "print(openshift_testgrid.json()[\"code-search-path\"])"
    ]
   },
   {
@@ -1613,7 +1613,7 @@
     }
    ],
    "source": [
-    "print(response1.json()[\"code-search-path\"])"
+    "print(jetstack_testgrid.json()[\"code-search-path\"])"
    ]
   },
   {
@@ -1627,7 +1627,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### overall-status"
+    "## overall-status"
    ]
   },
   {
@@ -1659,7 +1659,7 @@
     }
    ],
    "source": [
-    "print(response.json()[\"overall-status\"])"
+    "print(openshift_testgrid.json()[\"overall-status\"])"
    ]
   },
   {
@@ -1683,7 +1683,7 @@
     }
    ],
    "source": [
-    "print(response1.json()[\"overall-status\"])"
+    "print(jetstack_testgrid.json()[\"overall-status\"])"
    ]
   },
   {
@@ -1722,6 +1722,1191 @@
    "source": [
     "Image(filename=\"../../../docs/assets/images/testgrid_03.png\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## about-dashboard-url"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "''"
+      ]
+     },
+     "execution_count": 59,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "openshift_testgrid.json()[\"about-dashboard-url\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "''"
+      ]
+     },
+     "execution_count": 60,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "jetstack_testgrid.json()[\"about-dashboard-url\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Not entirely sure, but maybe this field shows the URL which describes this particular dashboard."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## results-text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "See these results on Prow\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(openshift_testgrid.json()[\"results-text\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This field usually just says \"see results on prow\". If we manually go the testgrid website : https://testgrid.k8s.io/redhat-openshift-ocp-release-4.2-informing#release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.1-to-4.2&show-stale-tests= and click on any test, we will be re-directed to the prow dashboard (https://prow.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.1-to-4.2/1371445677782994944) where we can find these results."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## latest-green"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(openshift_testgrid.json()[\"latest-green\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(jetstack_testgrid.json()[\"latest-green\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Not too sure what this should be returning. Manually checked this for a few other dashboards/tabs, but all were empty."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## triage-enabled"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "False\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(openshift_testgrid.json()[\"triage-enabled\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "False\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(openshift_testgrid.json()[\"triage-enabled\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition to the [testgrid](https://testgrid.k8s.io/) dashboard, Google has another dashboard called [triage](https://go.k8s.io/triage). This dashboard \"shows clusters of similar test failures across all jobs\", and suggests what general subject these failures related to e.g. storage. So this the value, **True** or **False**, returned in this field probably tells whether triage is enabled or not for this particular dashboard/tab."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## notifications"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(openshift_testgrid.json()[\"notifications\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(jetstack_testgrid.json()[\"notifications\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This value looks like should be returning the notifications if any. For various dashboards and jobs we looked at it however returned **None**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `xyz-template`-type fields\n",
+    "\n",
+    "\n",
+    "These fields are [instances](https://github.com/GoogleCloudPlatform/testgrid/blob/master/pb/response/types.proto#L147) of the [LinkTemplate](https://github.com/GoogleCloudPlatform/testgrid/blob/master/pb/config/config.pb.go#L1775) struct on the testgrid repo. These structs/jsons have three keys:\n",
+    "\n",
+    "1. url\n",
+    "2. name\n",
+    "3. options\n",
+    "\n",
+    "Together, these keys describe the format of various URLs where additional information regarding the tests can be found, where bugs can be filed, etc."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### open-test-template"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'url': 'https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>',\n",
+       " 'name': '',\n",
+       " 'options': {}}"
+      ]
+     },
+     "execution_count": 68,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "openshift_testgrid.json()[\"open-test-template\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'url': 'https://prow.k8s.io/view/gs/<gcs_prefix>/<changelist>',\n",
+       " 'name': '',\n",
+       " 'options': {}}"
+      ]
+     },
+     "execution_count": 69,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "jetstack_testgrid.json()[\"open-test-template\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This field seems to be the template for the URL where more details for a particular test can be found. That is, it's the \"general format\" for the Prow page for each test."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### file-bug-template"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 70,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'url': 'https://bugzilla.redhat.com/enter_bug.cgi',\n",
+       " 'name': '',\n",
+       " 'options': {'cf_environment': 'test: <test-name>',\n",
+       "  'cf_internal_whiteboard': 'buildcop',\n",
+       "  'classification': 'Red Hat',\n",
+       "  'comment': 'test: <test-name> failed, see job: <link>',\n",
+       "  'product': 'OpenShift Container Platform',\n",
+       "  'short_desc': 'test: <test-name>'}}"
+      ]
+     },
+     "execution_count": 70,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "openshift_testgrid.json()[\"file-bug-template\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 71,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'url': 'https://github.com/kubernetes/kubernetes/issues/new',\n",
+       " 'name': '',\n",
+       " 'options': {'body': '<test-url>', 'title': 'E2E: <test-name>'}}"
+      ]
+     },
+     "execution_count": 71,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "jetstack_testgrid.json()[\"file-bug-template\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This field seems to be the template for the URL where bugs can be filed for the respective organization/dashboard/job."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### attach-bug-template"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 72,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'url': '', 'name': '', 'options': {}}"
+      ]
+     },
+     "execution_count": 72,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "openshift_testgrid.json()[\"attach-bug-template\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 73,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'url': '', 'name': '', 'options': {}}"
+      ]
+     },
+     "execution_count": 73,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "jetstack_testgrid.json()[\"attach-bug-template\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is probably the template for URL where bugs can be attached. However, it's empty for all of the instances we looked into."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### results-url-template"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 74,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'url': 'https://prow.ci.openshift.org/job-history/<gcs_prefix>',\n",
+       " 'name': '',\n",
+       " 'options': {}}"
+      ]
+     },
+     "execution_count": 74,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "openshift_testgrid.json()[\"results-url-template\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 75,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'url': 'https://prow.k8s.io/job-history/<gcs_prefix>',\n",
+       " 'name': '',\n",
+       " 'options': {}}"
+      ]
+     },
+     "execution_count": 75,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "jetstack_testgrid.json()[\"results-url-template\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This field seems to be the template for the URL where historical results can be viewed. That is, the \"Job History\" tab on Prow for each test."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### code-search-url-template"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 76,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'url': 'https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>',\n",
+       " 'name': '',\n",
+       " 'options': {}}"
+      ]
+     },
+     "execution_count": 76,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "openshift_testgrid.json()[\"code-search-url-template\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 77,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'url': 'https://github.com/jetstack/cert-manager/compare/<start-custom-0>...<end-custom-0>',\n",
+       " 'name': '',\n",
+       " 'options': {}}"
+      ]
+     },
+     "execution_count": 77,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "jetstack_testgrid.json()[\"code-search-url-template\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This field is the template for the URL where you can view diffs / changes across branches (basically to the git \"Compare changes\" page)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### open-bug-template"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 78,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'url': 'https://github.com/openshift/origin/issues/',\n",
+       " 'name': '',\n",
+       " 'options': {}}"
+      ]
+     },
+     "execution_count": 78,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "openshift_testgrid.json()[\"open-bug-template\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 79,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'url': 'https://github.com/jetstack/cert-manager/issues/',\n",
+       " 'name': '',\n",
+       " 'options': {}}"
+      ]
+     },
+     "execution_count": 79,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "jetstack_testgrid.json()[\"open-bug-template\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This field seems to be the template for the URL that contains the link to issues page for the respective repository, however the name and options look empty."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### context-menu-template"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 80,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'url': '', 'name': '', 'options': {}}"
+      ]
+     },
+     "execution_count": 80,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "openshift_testgrid.json()[\"context-menu-template\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 81,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'url': '', 'name': '', 'options': {}}"
+      ]
+     },
+     "execution_count": 81,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "jetstack_testgrid.json()[\"context-menu-template\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This field is mostly empty for all intances we looked into. So not sure what this URL is supposed to be."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Metadata within the `statuses` field"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 82,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dict_keys(['name', 'original-name', 'alert', 'linked_bugs', 'messages', 'short_texts', 'statuses', 'target', 'user_property'])\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(openshift_testgrid.json()[\"tests\"][0].keys())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 83,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dict_keys(['name', 'original-name', 'alert', 'linked_bugs', 'messages', 'short_texts', 'statuses', 'target', 'user_property'])\n"
+     ]
+    }
+   ],
+   "source": [
+    "print((jetstack_testgrid.json()[\"tests\"][0].keys()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### linked_bugs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 84,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print((openshift_testgrid.json()[\"tests\"][0])[\"linked_bugs\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 85,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print((jetstack_testgrid.json()[\"tests\"][0])[\"linked_bugs\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 86,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Checking OpenShift dashboard\n",
+      "Checking non-OpenShift dashboard\n"
+     ]
+    }
+   ],
+   "source": [
+    "# is this non-empty for any other test in any other tabs?\n",
+    "print(\"Checking OpenShift dashboard\")\n",
+    "for t in openshift_testgrid.json()[\"tests\"]:\n",
+    "    if len(t[\"linked_bugs\"]):\n",
+    "        print(t[\"linked_bugs\"])\n",
+    "\n",
+    "print(\"Checking non-OpenShift dashboard\")\n",
+    "for t in jetstack_testgrid.json()[\"tests\"]:\n",
+    "    if len(t[\"linked_bugs\"]):\n",
+    "        print(t[\"linked_bugs\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Linked bugs is empty."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### messages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 87,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['', '', '', '', '', '', '', '', '', '', '', '', 'Build failed outside of test results', '', 'Build failed outside of test results', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '']\n"
+     ]
+    }
+   ],
+   "source": [
+    "print((openshift_testgrid.json()[\"tests\"][0])[\"messages\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 88,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[\"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\", \"podinfo.json not found, please install prow's GCS reporter\"]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print((jetstack_testgrid.json()[\"tests\"][0])[\"messages\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 89,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "170"
+      ]
+     },
+     "execution_count": 89,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len((jetstack_testgrid.json()[\"tests\"][0])[\"messages\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Messages contains messages for first few tests of openshift testgrid but good information for jetstack testgrid."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### short_texts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 90,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['', '', '', '', '', '', '', '', '', '', '', '', 'F', '', 'F', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '']\n"
+     ]
+    }
+   ],
+   "source": [
+    "print((openshift_testgrid.json()[\"tests\"][0])[\"short_texts\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 91,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!', '!']\n"
+     ]
+    }
+   ],
+   "source": [
+    "print((jetstack_testgrid.json()[\"tests\"][0])[\"short_texts\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 92,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', 'F', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', 'F', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '']\n"
+     ]
+    }
+   ],
+   "source": [
+    "print((jetstack_testgrid.json()[\"tests\"][1])[\"short_texts\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Not sure what `F` or `!` signify here. No documentation found about what this could signify."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### user_property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 93,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "None\n"
+     ]
+    }
+   ],
+   "source": [
+    "print((openshift_testgrid.json()[\"tests\"][0])[\"user_property\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 94,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "None\n"
+     ]
+    }
+   ],
+   "source": [
+    "print((jetstack_testgrid.json()[\"tests\"][0])[\"user_property\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 95,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Checking OpenShift dashboard\n",
+      "Checking non-OpenShift dashboard\n"
+     ]
+    }
+   ],
+   "source": [
+    "# is this non-None for any other test in any other tabs?\n",
+    "print(\"Checking OpenShift dashboard\")\n",
+    "for t in openshift_testgrid.json()[\"tests\"]:\n",
+    "    if t[\"user_property\"] is not None:\n",
+    "        print(t[\"user_property\"])\n",
+    "\n",
+    "print(\"Checking non-OpenShift dashboard\")\n",
+    "for t in jetstack_testgrid.json()[\"tests\"]:\n",
+    "    if t[\"user_property\"] is not None:\n",
+    "        print(t[\"user_property\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This field is empty for all tests in all the dashboards we looked at. Therefore we can't determine exactly what this field means. Nonetheless, based off of the comment [here](https://github.com/GoogleCloudPlatform/testgrid/blob/1dbc0e8b6ef997b9c90b3fb79518c35ce4d27ea2/pb/state/state.pb.go#L537), it seems that `user_property` is any custom, user-defined property that can be associated with a test result."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### target"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 96,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Overall\n"
+     ]
+    }
+   ],
+   "source": [
+    "print((openshift_testgrid.json()[\"tests\"][0])[\"target\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 97,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pod\n"
+     ]
+    }
+   ],
+   "source": [
+    "print((jetstack_testgrid.json()[\"tests\"][0])[\"target\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 98,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Checking OpenShift dashboard\n",
+      "Checking non-OpenShift dashboard\n"
+     ]
+    }
+   ],
+   "source": [
+    "# is \"target\" same as \"name\"?\n",
+    "print(\"Checking OpenShift dashboard\")\n",
+    "for t in openshift_testgrid.json()[\"tests\"]:\n",
+    "    if t[\"target\"] != t[\"name\"]:\n",
+    "        print(t[\"target\"])\n",
+    "        print(t[\"name\"])\n",
+    "\n",
+    "print(\"Checking non-OpenShift dashboard\")\n",
+    "for t in jetstack_testgrid.json()[\"tests\"]:\n",
+    "    if t[\"target\"] != t[\"name\"]:\n",
+    "        print(t[\"target\"])\n",
+    "        print(t[\"name\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This value in this field is the same as the value in `name` for all tests in all the dashboards we looked at. We couldn't find any strong evidence in the testgrid repo that could explain the difference. Therefore we can't determine exactly how this field is different than test `name`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### original-name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 99,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Overall\n"
+     ]
+    }
+   ],
+   "source": [
+    "print((openshift_testgrid.json()[\"tests\"][0])[\"original-name\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 100,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pod\n"
+     ]
+    }
+   ],
+   "source": [
+    "print((jetstack_testgrid.json()[\"tests\"][0])[\"original-name\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 101,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Checking OpenShift dashboard\n",
+      "Checking non-OpenShift dashboard\n"
+     ]
+    }
+   ],
+   "source": [
+    "# is \"original-name\" same as \"name\"?\n",
+    "print(\"Checking OpenShift dashboard\")\n",
+    "for t in openshift_testgrid.json()[\"tests\"]:\n",
+    "    if t[\"original-name\"] != t[\"name\"]:\n",
+    "        print(t[\"original-name\"])\n",
+    "        print(t[\"name\"])\n",
+    "\n",
+    "print(\"Checking non-OpenShift dashboard\")\n",
+    "for t in jetstack_testgrid.json()[\"tests\"]:\n",
+    "    if t[\"original-name\"] != t[\"name\"]:\n",
+    "        print(t[\"original-name\"])\n",
+    "        print(t[\"name\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This value in this field is the same as the value in `name` for all tests in all the dashboards we looked at. We couldn't find any strong evidence in the testgrid repo that could explain the difference. Therefore we can't determine exactly how this field is different than test `name`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Conclusion\n",
+    "\n",
+    "In this notebook, we explored all the metadata fields in the testgrid json data. From the results above, it seems that not all metadata is created equal and that some fields are more useful for data analysis than the others. Specifically, the following fields seem to have more valueable information:\n",
+    "\n",
+    "- `query`: The \"gcs_prefix\" value here can be used for contstructing prow URL for each test\n",
+    "- `changelists`: The \"ids\" value here can be used for contstructing prow URL for each test\n",
+    "- `custom-column`: Although not properly populated for OpenShift dashboards, in general the values here show the commit ids corresponding to each test run. These can later be used for other types of analysis such as determining what code resulted in passing tests vs failing test, etc.\n",
+    "- `metrics`: The \"test-duration-minutes\" value here is useful\n",
+    "- `row_ids`: This provides the list of test names. Maybe this can be used in the labelwise_encode function (instead of getting test names in a for loop, we can directly set test names to be the value in this field)\n",
+    "- `timestamps`: Run timestamps\n",
+    "- `clusters`: Seems useful because it provides similar tests, but it's not heavily populated for OpenShift dashboards\n",
+    "- `num-stale-tests`: Gives an idea of \"health\" of test runs (are all tests getting run? how many have not been run in a long time?)\n",
+    "- `stale-test-threshold`: Might be useful, as it gives context for how severe of a job health indicator the number above is\n",
+    "- `code-search-path`: Provides the GitHub link for diff'ing across PRs/commits\n",
+    "- `overall-status`: Gives job summary\n",
+    "- `open-test-template`: The template here can be used with query and changelists values to get relevant URLs\n",
+    "- `file-bug-template`: The template here can be used with query and changelists values to get relevant URLs\n",
+    "- `open-bug-template`: The template here can be used with query and changelists values to get relevant URLs\n",
+    "- `results-url-template`: The template here can be used with query and changelists values to get relevant URLs\n",
+    "- `code-search-url-template`: The template here can be used with query and changelists values to get relevant URLs\n",
+    "- `messages`: Contains some error messages from running the test, but not very densely populated.\n",
+    "\n",
+    "\n",
+    "Lastly, the following fields seem to be either noise or empty or repetiions of data already included in other fields.\n",
+    "\n",
+    "- linked-bugs\n",
+    "    - NOTE: Maybe this could have been a very useful field, but it was found to be always empty. \n",
+    "- bugs\n",
+    "    - NOTE: Maybe this could have been a very useful field, but it was found to be always empty. \n",
+    "- cached\n",
+    "- phase-timer\n",
+    "- test-group-name\n",
+    "- status\n",
+    "- column_ids\n",
+    "- column-header-names\n",
+    "- groups\n",
+    "- test-id-map\n",
+    "- test-metadata\n",
+    "- add-tabular-name-option\n",
+    "- show-tabular-names\n",
+    "- description\n",
+    "- bug-component\n",
+    "- about-dashboard-url\n",
+    "- results-text\n",
+    "- latest-green\n",
+    "- triage-enabled\n",
+    "- notifications\n",
+    "- short_texts\n",
+    "- attach-bug-template\n",
+    "- context-menu-template\n",
+    "- target\n",
+    "- original-name\n",
+    "- user_property"
+   ]
   }
  ],
  "metadata": {
@@ -1744,7 +2929,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.6.8"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes #144 

## This introduces a breaking change

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
Moves the metadata EDA notebook out of the stage directory (and as a result, the stage directory gets deleted)

## This Pull Request implements

Adds EDA and descriptions for the fields that were not already included in the metadata EDA notebook.