### PR TITLE
pipeline for all metric notebooks

### DIFF
--- a/notebooks/data-sources/TestGrid/metrics/correlated_failures.ipynb
+++ b/notebooks/data-sources/TestGrid/metrics/correlated_failures.ipynb
@@ -1049,9 +1049,10 @@
     }
    ],
    "source": [
-    "test_name = \"openshift-tests.[k8s.io] Security Context When creating a container with runAsUser should run the container with uid 65534 [LinuxOnly] [NodeConformance] [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]\"  # noqa\n",
-    "num = occurrence_count.loc[test_name]\n",
-    "print(f\"{num} : the number of times this test failed in our data set\")"
+    "if not AUTOMATION:\n",
+    "    test_name = \"openshift-tests.[k8s.io] Security Context When creating a container with runAsUser should run the container with uid 65534 [LinuxOnly] [NodeConformance] [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]\"  # noqa\n",
+    "    num = occurrence_count.loc[test_name]\n",
+    "    print(f\"{num} : the number of times this test failed in our data set\")"
    ]
   },
   {

--- a/notebooks/data-sources/TestGrid/metrics/ocp-ci.pipeline
+++ b/notebooks/data-sources/TestGrid/metrics/ocp-ci.pipeline
@@ -17,9 +17,9 @@
             "runtime_image": "quay.io/aicoe/ocp-ci-analysis:latest",
             "env_vars": [
               "S3_ENDPOINT=http://s3.openshift-storage.svc/",
-              "S3_ACCESS_KEY=VmLs0BX6DrlemWaL8lIZ",
-              "S3_SECRET_KEY=Mit8aMETyC4RhC8NQMq1udACywu5YVnkU4YzCd4u",
-              "S3_BUCKET=test-public-bucket-596bc441-3be5-42e7-a82c-49736fa8b42a",
+              "S3_ACCESS_KEY=v3FnruQ78kfeULDjejUB",
+              "S3_SECRET_KEY=kJiDiHXncLJOXbaL7Zeb5Ok+gkLt9sWIa1rWAJa0",
+              "S3_BUCKET=opf-datacatalog",
               "IN_AUTOMATION=True"
             ],
             "include_subdirectories": false,
@@ -33,8 +33,8 @@
             "ui_data": {
               "label": "get_raw_data.ipynb",
               "image": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20viewBox%3D%220%200%2022%2022%22%3E%0A%20%20%3Cg%20class%3D%22jp-icon-warn0%20jp-icon-selectable%22%20fill%3D%22%23EF6C00%22%3E%0A%20%20%20%20%3Cpath%20d%3D%22M18.7%203.3v15.4H3.3V3.3h15.4m1.5-1.5H1.8v18.3h18.3l.1-18.3z%22%2F%3E%0A%20%20%20%20%3Cpath%20d%3D%22M16.5%2016.5l-5.4-4.3-5.6%204.3v-11h11z%22%2F%3E%0A%20%20%3C%2Fg%3E%0A%3C%2Fsvg%3E%0A",
-              "x_pos": 197,
-              "y_pos": 197,
+              "x_pos": 56.99999237060547,
+              "y_pos": 304.00001525878906,
               "description": "Notebook file"
             }
           },
@@ -76,9 +76,9 @@
             "runtime_image": "quay.io/aicoe/ocp-ci-analysis:latest",
             "env_vars": [
               "S3_ENDPOINT=http://s3.openshift-storage.svc/",
-              "S3_ACCESS_KEY=VmLs0BX6DrlemWaL8lIZ",
-              "S3_SECRET_KEY=Mit8aMETyC4RhC8NQMq1udACywu5YVnkU4YzCd4u",
-              "S3_BUCKET=test-public-bucket-596bc441-3be5-42e7-a82c-49736fa8b42a",
+              "S3_ACCESS_KEY=v3FnruQ78kfeULDjejUB",
+              "S3_SECRET_KEY=kJiDiHXncLJOXbaL7Zeb5Ok+gkLt9sWIa1rWAJa0",
+              "S3_BUCKET=opf-datacatalog",
               "IN_AUTOMATION=True"
             ],
             "include_subdirectories": false,
@@ -92,8 +92,8 @@
             "ui_data": {
               "label": "number_of_flakes.ipynb",
               "image": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20viewBox%3D%220%200%2022%2022%22%3E%0A%20%20%3Cg%20class%3D%22jp-icon-warn0%20jp-icon-selectable%22%20fill%3D%22%23EF6C00%22%3E%0A%20%20%20%20%3Cpath%20d%3D%22M18.7%203.3v15.4H3.3V3.3h15.4m1.5-1.5H1.8v18.3h18.3l.1-18.3z%22%2F%3E%0A%20%20%20%20%3Cpath%20d%3D%22M16.5%2016.5l-5.4-4.3-5.6%204.3v-11h11z%22%2F%3E%0A%20%20%3C%2Fg%3E%0A%3C%2Fsvg%3E%0A",
-              "x_pos": 500,
-              "y_pos": 220,
+              "x_pos": 454,
+              "y_pos": 65,
               "description": "Notebook file"
             }
           },
@@ -111,7 +111,471 @@
               },
               "links": [
                 {
-                  "id": "5d4a1945-4256-403d-9bba-ecda4532b16a",
+                  "id": "3dcdbe18-5edf-40ab-b3f0-428f8fb0fffc",
+                  "node_id_ref": "7228b5b9-2a78-4988-9dbd-4d48982b2931",
+                  "port_id_ref": "outPort"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "id": "outPort",
+              "app_data": {
+                "ui_data": {
+                  "cardinality": {
+                    "min": 0,
+                    "max": -1
+                  },
+                  "label": "Output Port"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "966277bf-d8cc-44b8-ba88-b792f3601fe0",
+          "type": "execution_node",
+          "op": "execute-notebook-node",
+          "app_data": {
+            "filename": "blocked_timed_out.ipynb",
+            "runtime_image": "quay.io/aicoe/ocp-ci-analysis:latest",
+            "env_vars": [
+              "S3_ENDPOINT=http://s3.openshift-storage.svc/",
+              "S3_ACCESS_KEY=v3FnruQ78kfeULDjejUB",
+              "S3_SECRET_KEY=kJiDiHXncLJOXbaL7Zeb5Ok+gkLt9sWIa1rWAJa0",
+              "S3_BUCKET=opf-datacatalog",
+              "IN_AUTOMATION=True"
+            ],
+            "include_subdirectories": false,
+            "invalidNodeError": null,
+            "outputs": [],
+            "dependencies": [
+              "metric_template.ipynb"
+            ],
+            "cpu": 4,
+            "memory": 16,
+            "ui_data": {
+              "label": "blocked_timed_out.ipynb",
+              "image": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20viewBox%3D%220%200%2022%2022%22%3E%0A%20%20%3Cg%20class%3D%22jp-icon-warn0%20jp-icon-selectable%22%20fill%3D%22%23EF6C00%22%3E%0A%20%20%20%20%3Cpath%20d%3D%22M18.7%203.3v15.4H3.3V3.3h15.4m1.5-1.5H1.8v18.3h18.3l.1-18.3z%22%2F%3E%0A%20%20%20%20%3Cpath%20d%3D%22M16.5%2016.5l-5.4-4.3-5.6%204.3v-11h11z%22%2F%3E%0A%20%20%3C%2Fg%3E%0A%3C%2Fsvg%3E%0A",
+              "x_pos": 630,
+              "y_pos": 514.9999847412109,
+              "description": "Notebook file"
+            }
+          },
+          "inputs": [
+            {
+              "id": "inPort",
+              "app_data": {
+                "ui_data": {
+                  "cardinality": {
+                    "min": 0,
+                    "max": -1
+                  },
+                  "label": "Input Port"
+                }
+              },
+              "links": [
+                {
+                  "id": "da5abb7e-e4d9-4c02-b660-7649920507a7",
+                  "node_id_ref": "7228b5b9-2a78-4988-9dbd-4d48982b2931",
+                  "port_id_ref": "outPort"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "id": "outPort",
+              "app_data": {
+                "ui_data": {
+                  "cardinality": {
+                    "min": 0,
+                    "max": -1
+                  },
+                  "label": "Output Port"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "bc90e9be-a169-49eb-88c4-74ae2f89148a",
+          "type": "execution_node",
+          "op": "execute-notebook-node",
+          "app_data": {
+            "filename": "build_pass_failure.ipynb",
+            "runtime_image": "quay.io/aicoe/ocp-ci-analysis:latest",
+            "env_vars": [
+              "S3_ENDPOINT=http://s3.openshift-storage.svc/",
+              "S3_ACCESS_KEY=v3FnruQ78kfeULDjejUB",
+              "S3_SECRET_KEY=kJiDiHXncLJOXbaL7Zeb5Ok+gkLt9sWIa1rWAJa0",
+              "S3_BUCKET=opf-datacatalog",
+              null,
+              "IN_AUTOMATION=True",
+              null
+            ],
+            "include_subdirectories": false,
+            "invalidNodeError": null,
+            "outputs": [],
+            "dependencies": [
+              "metric_template.ipynb"
+            ],
+            "cpu": 4,
+            "memory": 16,
+            "ui_data": {
+              "label": "build_pass_failure.ipynb",
+              "image": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20viewBox%3D%220%200%2022%2022%22%3E%0A%20%20%3Cg%20class%3D%22jp-icon-warn0%20jp-icon-selectable%22%20fill%3D%22%23EF6C00%22%3E%0A%20%20%20%20%3Cpath%20d%3D%22M18.7%203.3v15.4H3.3V3.3h15.4m1.5-1.5H1.8v18.3h18.3l.1-18.3z%22%2F%3E%0A%20%20%20%20%3Cpath%20d%3D%22M16.5%2016.5l-5.4-4.3-5.6%204.3v-11h11z%22%2F%3E%0A%20%20%3C%2Fg%3E%0A%3C%2Fsvg%3E%0A",
+              "x_pos": 700,
+              "y_pos": 399,
+              "description": "Notebook file"
+            }
+          },
+          "inputs": [
+            {
+              "id": "inPort",
+              "app_data": {
+                "ui_data": {
+                  "cardinality": {
+                    "min": 0,
+                    "max": -1
+                  },
+                  "label": "Input Port"
+                }
+              },
+              "links": [
+                {
+                  "id": "1750d05d-a937-4e19-9993-1de3b3726d56",
+                  "node_id_ref": "7228b5b9-2a78-4988-9dbd-4d48982b2931",
+                  "port_id_ref": "outPort"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "id": "outPort",
+              "app_data": {
+                "ui_data": {
+                  "cardinality": {
+                    "min": 0,
+                    "max": -1
+                  },
+                  "label": "Output Port"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "77d4815e-03a3-44f3-83d9-be53917de928",
+          "type": "execution_node",
+          "op": "execute-notebook-node",
+          "app_data": {
+            "filename": "correlated_failures.ipynb",
+            "runtime_image": "quay.io/aicoe/ocp-ci-analysis:latest",
+            "env_vars": [
+              "S3_ENDPOINT=http://s3.openshift-storage.svc/",
+              "S3_ACCESS_KEY=v3FnruQ78kfeULDjejUB",
+              "S3_SECRET_KEY=kJiDiHXncLJOXbaL7Zeb5Ok+gkLt9sWIa1rWAJa0",
+              "S3_BUCKET=opf-datacatalog",
+              "IN_AUTOMATION=True"
+            ],
+            "include_subdirectories": false,
+            "invalidNodeError": null,
+            "outputs": [],
+            "dependencies": [
+              "metric_template.ipynb"
+            ],
+            "cpu": 4,
+            "memory": 16,
+            "ui_data": {
+              "label": "correlated_failures.ipynb",
+              "image": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20viewBox%3D%220%200%2022%2022%22%3E%0A%20%20%3Cg%20class%3D%22jp-icon-warn0%20jp-icon-selectable%22%20fill%3D%22%23EF6C00%22%3E%0A%20%20%20%20%3Cpath%20d%3D%22M18.7%203.3v15.4H3.3V3.3h15.4m1.5-1.5H1.8v18.3h18.3l.1-18.3z%22%2F%3E%0A%20%20%20%20%3Cpath%20d%3D%22M16.5%2016.5l-5.4-4.3-5.6%204.3v-11h11z%22%2F%3E%0A%20%20%3C%2Fg%3E%0A%3C%2Fsvg%3E%0A",
+              "x_pos": 574,
+              "y_pos": 141.99998474121094,
+              "description": "Notebook file"
+            }
+          },
+          "inputs": [
+            {
+              "id": "inPort",
+              "app_data": {
+                "ui_data": {
+                  "cardinality": {
+                    "min": 0,
+                    "max": -1
+                  },
+                  "label": "Input Port"
+                }
+              },
+              "links": [
+                {
+                  "id": "a24b5884-b5c2-4ac3-9679-1f5d4e6509f7",
+                  "node_id_ref": "7228b5b9-2a78-4988-9dbd-4d48982b2931",
+                  "port_id_ref": "outPort"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "id": "outPort",
+              "app_data": {
+                "ui_data": {
+                  "cardinality": {
+                    "min": 0,
+                    "max": -1
+                  },
+                  "label": "Output Port"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "28ddfcb7-cbfd-4756-b222-92223a7208be",
+          "type": "execution_node",
+          "op": "execute-notebook-node",
+          "app_data": {
+            "filename": "pct_fixed_each_ts.ipynb",
+            "runtime_image": "quay.io/aicoe/ocp-ci-analysis:latest",
+            "env_vars": [
+              "S3_ENDPOINT=http://s3.openshift-storage.svc/",
+              "S3_ACCESS_KEY=v3FnruQ78kfeULDjejUB",
+              "S3_SECRET_KEY=kJiDiHXncLJOXbaL7Zeb5Ok+gkLt9sWIa1rWAJa0",
+              "S3_BUCKET=opf-datacatalog",
+              "IN_AUTOMATION=True"
+            ],
+            "include_subdirectories": false,
+            "invalidNodeError": null,
+            "outputs": [],
+            "dependencies": [
+              "metric_template.ipynb"
+            ],
+            "cpu": 4,
+            "memory": 65,
+            "ui_data": {
+              "label": "pct_fixed_each_ts.ipynb",
+              "image": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20viewBox%3D%220%200%2022%2022%22%3E%0A%20%20%3Cg%20class%3D%22jp-icon-warn0%20jp-icon-selectable%22%20fill%3D%22%23EF6C00%22%3E%0A%20%20%20%20%3Cpath%20d%3D%22M18.7%203.3v15.4H3.3V3.3h15.4m1.5-1.5H1.8v18.3h18.3l.1-18.3z%22%2F%3E%0A%20%20%20%20%3Cpath%20d%3D%22M16.5%2016.5l-5.4-4.3-5.6%204.3v-11h11z%22%2F%3E%0A%20%20%3C%2Fg%3E%0A%3C%2Fsvg%3E%0A",
+              "x_pos": 673,
+              "y_pos": 214.99998474121094,
+              "description": "Notebook file"
+            }
+          },
+          "inputs": [
+            {
+              "id": "inPort",
+              "app_data": {
+                "ui_data": {
+                  "cardinality": {
+                    "min": 0,
+                    "max": -1
+                  },
+                  "label": "Input Port"
+                }
+              },
+              "links": [
+                {
+                  "id": "9bbb5e3a-ef2c-4184-82d0-33a59afd379a",
+                  "node_id_ref": "7228b5b9-2a78-4988-9dbd-4d48982b2931",
+                  "port_id_ref": "outPort"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "id": "outPort",
+              "app_data": {
+                "ui_data": {
+                  "cardinality": {
+                    "min": 0,
+                    "max": -1
+                  },
+                  "label": "Output Port"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "179489fb-bee4-464b-a314-40a4625faf53",
+          "type": "execution_node",
+          "op": "execute-notebook-node",
+          "app_data": {
+            "filename": "persistent_failures_analysis.ipynb",
+            "runtime_image": "quay.io/aicoe/ocp-ci-analysis:latest",
+            "env_vars": [
+              "S3_ENDPOINT=http://s3.openshift-storage.svc/",
+              "S3_ACCESS_KEY=v3FnruQ78kfeULDjejUB",
+              "S3_SECRET_KEY=kJiDiHXncLJOXbaL7Zeb5Ok+gkLt9sWIa1rWAJa0",
+              "S3_BUCKET=opf-datacatalog",
+              "IN_AUTOMATION=True"
+            ],
+            "include_subdirectories": false,
+            "invalidNodeError": null,
+            "outputs": [],
+            "dependencies": [
+              "metric_template.ipynb"
+            ],
+            "cpu": 4,
+            "memory": 16,
+            "ui_data": {
+              "label": "persistent_failures_analysis.ipynb",
+              "image": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20viewBox%3D%220%200%2022%2022%22%3E%0A%20%20%3Cg%20class%3D%22jp-icon-warn0%20jp-icon-selectable%22%20fill%3D%22%23EF6C00%22%3E%0A%20%20%20%20%3Cpath%20d%3D%22M18.7%203.3v15.4H3.3V3.3h15.4m1.5-1.5H1.8v18.3h18.3l.1-18.3z%22%2F%3E%0A%20%20%20%20%3Cpath%20d%3D%22M16.5%2016.5l-5.4-4.3-5.6%204.3v-11h11z%22%2F%3E%0A%20%20%3C%2Fg%3E%0A%3C%2Fsvg%3E%0A",
+              "x_pos": 691.9950561523438,
+              "y_pos": 95.96393585205078,
+              "description": "Notebook file"
+            }
+          },
+          "inputs": [
+            {
+              "id": "inPort",
+              "app_data": {
+                "ui_data": {
+                  "cardinality": {
+                    "min": 0,
+                    "max": -1
+                  },
+                  "label": "Input Port"
+                }
+              },
+              "links": [
+                {
+                  "id": "865b13ed-2081-48d7-b863-4c5f5a60452f",
+                  "node_id_ref": "7228b5b9-2a78-4988-9dbd-4d48982b2931",
+                  "port_id_ref": "outPort"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "id": "outPort",
+              "app_data": {
+                "ui_data": {
+                  "cardinality": {
+                    "min": 0,
+                    "max": -1
+                  },
+                  "label": "Output Port"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "00ef6c31-35bf-4906-8371-c63495aa15b6",
+          "type": "execution_node",
+          "op": "execute-notebook-node",
+          "app_data": {
+            "filename": "test_pass_failures.ipynb",
+            "runtime_image": "quay.io/aicoe/ocp-ci-analysis:latest",
+            "env_vars": [
+              "S3_ENDPOINT=http://s3.openshift-storage.svc/",
+              "S3_ACCESS_KEY=v3FnruQ78kfeULDjejUB",
+              "S3_SECRET_KEY=kJiDiHXncLJOXbaL7Zeb5Ok+gkLt9sWIa1rWAJa0",
+              "S3_BUCKET=opf-datacatalog",
+              "IN_AUTOMATION=True"
+            ],
+            "include_subdirectories": false,
+            "invalidNodeError": null,
+            "outputs": [],
+            "dependencies": [
+              "metric_template.ipynb"
+            ],
+            "cpu": 4,
+            "memory": 16,
+            "ui_data": {
+              "label": "test_pass_failures.ipynb",
+              "image": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20viewBox%3D%220%200%2022%2022%22%3E%0A%20%20%3Cg%20class%3D%22jp-icon-warn0%20jp-icon-selectable%22%20fill%3D%22%23EF6C00%22%3E%0A%20%20%20%20%3Cpath%20d%3D%22M18.7%203.3v15.4H3.3V3.3h15.4m1.5-1.5H1.8v18.3h18.3l.1-18.3z%22%2F%3E%0A%20%20%20%20%3Cpath%20d%3D%22M16.5%2016.5l-5.4-4.3-5.6%204.3v-11h11z%22%2F%3E%0A%20%20%3C%2Fg%3E%0A%3C%2Fsvg%3E%0A",
+              "x_pos": 704.8891906738281,
+              "y_pos": 297.79388427734375,
+              "description": "Notebook file"
+            }
+          },
+          "inputs": [
+            {
+              "id": "inPort",
+              "app_data": {
+                "ui_data": {
+                  "cardinality": {
+                    "min": 0,
+                    "max": -1
+                  },
+                  "label": "Input Port"
+                }
+              },
+              "links": [
+                {
+                  "id": "abac6386-fa70-4892-b122-52f868c2b6b7",
+                  "node_id_ref": "7228b5b9-2a78-4988-9dbd-4d48982b2931",
+                  "port_id_ref": "outPort"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "id": "outPort",
+              "app_data": {
+                "ui_data": {
+                  "cardinality": {
+                    "min": 0,
+                    "max": -1
+                  },
+                  "label": "Output Port"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "0d218ff8-d4bc-44b9-91a7-751e21aeef54",
+          "type": "execution_node",
+          "op": "execute-notebook-node",
+          "app_data": {
+            "filename": "time_to_test.ipynb",
+            "runtime_image": "quay.io/aicoe/ocp-ci-analysis:latest",
+            "env_vars": [
+              "S3_ENDPOINT=http://s3.openshift-storage.svc/",
+              "S3_ACCESS_KEY=v3FnruQ78kfeULDjejUB",
+              "S3_SECRET_KEY=kJiDiHXncLJOXbaL7Zeb5Ok+gkLt9sWIa1rWAJa0",
+              "S3_BUCKET=opf-datacatalog",
+              "IN_AUTOMATION=True"
+            ],
+            "include_subdirectories": false,
+            "outputs": [],
+            "dependencies": [
+              "metric_template.ipynb"
+            ],
+            "cpu": 4,
+            "memory": 16,
+            "invalidNodeError": null,
+            "ui_data": {
+              "label": "time_to_test.ipynb",
+              "image": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20viewBox%3D%220%200%2022%2022%22%3E%0A%20%20%3Cg%20class%3D%22jp-icon-warn0%20jp-icon-selectable%22%20fill%3D%22%23EF6C00%22%3E%0A%20%20%20%20%3Cpath%20d%3D%22M18.7%203.3v15.4H3.3V3.3h15.4m1.5-1.5H1.8v18.3h18.3l.1-18.3z%22%2F%3E%0A%20%20%20%20%3Cpath%20d%3D%22M16.5%2016.5l-5.4-4.3-5.6%204.3v-11h11z%22%2F%3E%0A%20%20%3C%2Fg%3E%0A%3C%2Fsvg%3E%0A",
+              "x_pos": 165,
+              "y_pos": 67.99998474121094,
+              "description": "Notebook file"
+            }
+          },
+          "inputs": [
+            {
+              "id": "inPort",
+              "app_data": {
+                "ui_data": {
+                  "cardinality": {
+                    "min": 0,
+                    "max": -1
+                  },
+                  "label": "Input Port"
+                }
+              },
+              "links": [
+                {
+                  "id": "3f2afe8e-1971-4cc0-a752-ec75085715fd",
                   "node_id_ref": "7228b5b9-2a78-4988-9dbd-4d48982b2931",
                   "port_id_ref": "outPort"
                 }


### PR DESCRIPTION
## Related Issues and Dependencies

#124 

We have all metric notebooks running using KFP Pipelines and Elyra. 

![image](https://user-images.githubusercontent.com/32435206/115060069-683c8d00-9eb5-11eb-9866-eb7a49132a33.png)

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

* Updated KFP Pipeline including all metric notebooks metadata.
* Added an automation flag to correlated_failures notebook to avoid errors during automation.

