### PR TITLE
remove md cell dividers which cause op1st website build to fail

### DIFF
--- a/notebooks/data-sources/oc-github-repo/github_PR_EDA.ipynb
+++ b/notebooks/data-sources/oc-github-repo/github_PR_EDA.ipynb
@@ -503,14 +503,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ca4610f8",
-   "metadata": {},
-   "source": [
-    "-------------------------------------------------"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "dbd374f9",
    "metadata": {},
    "source": [
@@ -2849,14 +2841,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ceb9d2aa",
-   "metadata": {},
-   "source": [
-    "-----------------------------------"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "0e706dcb",
    "metadata": {},
    "source": [
@@ -4263,14 +4247,6 @@
     "\n",
     "As next steps, we will evaluate the importance of the defined features and train a machine learning model to predict time to merge of a PR using the features."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "38bae837-9290-421a-b835-f40dd5566aad",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Related Issues and Dependencies
resolves https://github.com/operate-first/operate-first.github.io/issues/267

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

The operate first website is currently failing builds due to long line breaks present in notebooks. This PR implements a minor change in the `github_PR_EDA` notebook to remove line breaks, such that we can trigger a re-build of the site.

This allows new content to be updated on the site.

cc: @margarethaley @Shreyanand 
