### PR TITLE
Changed metric paths

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -2,4 +2,5 @@ S3_ENDPOINT=<insert-endpoint>
 S3_ACCESS_KEY=<insert-access-key>
 S3_SECRET_KEY=<insert-secret-key>
 S3_BUCKET=<insert-bucket-name>
+S3_PROJECT_KEY=<path-to-dataset-or-model>
 IN_AUTOMATION=True

--- a/docs/how-to-contribute.md
+++ b/docs/how-to-contribute.md
@@ -8,7 +8,7 @@ In order to quantify and evaluate the current state of the CI workflow, we have 
 
 - In order to include an additional KPI, you can open a KPI Request [issue](https://github.com/aicoe-aiops/ocp-ci-analysis/issues?q=is%3Aissue+is%3Aopen+%22KPI+Request%22+). Specify the KPI you wish to collect with the prefix `KPI Request:`.
 - In order to add a notebook to fulfill one of the existing open `KPI Request:` issues, you can use the [KPI template notebook](../notebooks/data-sources/TestGrid/metrics/metric_template.ipynb). The template notebook has helper functions and examples to make contributing new metrics as simple and as uniform as possible.
-- When defining the file prefix for your metrics stored in the shared ceph instance, please be sure to use the following format: `s3://opf-datacatalog/ai4ci/<dat_source>/metrics/<metric_name>/<date_analysis_was_generated>.parquet`
+- When defining the file prefix for your metrics stored in the shared ceph instance, please be sure to use the following format: `s3://<bucket-name>/ai4ci/<data_source>/metrics/<metric_name>/<metric_name>-timestamp_analysis_was_generated>.parquet`
 - Submit a Pull Request to the [project repo](https://github.com/aicoe-aiops/ocp-ci-analysis) with your KPI analysis notebook.
 - In order to add the notebook to the automated Kubeflow workflow, follow intructions in the [guide](automating-using-elyra.md).
 
@@ -17,6 +17,6 @@ In order to quantify and evaluate the current state of the CI workflow, we have 
 With the necessary KPIs available to quantify and evaluate the CI workflow, we can start to apply some AI and machine learning techniques to help improve the CI workflow. We encourage you to contribute to this work developing additional machine learning analyses or adding features to the existing analyses.
 
 - In order to include an additional ML Analysis, you can open an ML Request [issue](https://github.com/aicoe-aiops/ocp-ci-analysis/issues?q=is%3Aissue+is%3Aopen+%22ML+Request%22+). Specify the machine learning application you would like to have included with the prefix `ML Request:`.
-- When uploading your model to the shared ceph storage instance please use the following prefix format to ensure no files get overwritten: `s3://opf-datacatalog/ai4ci/<ML_directory_name>/model/<model_file>`
+- When uploading your model to the shared ceph storage instance please use the following prefix format to ensure no files get overwritten: `s3://<bucket-name>/ai4ci/<ML_directory_name>/model/<model_file>`
 - Submit a Pull Request to the [project repo](https://github.com/aicoe-aiops/ocp-ci-analysis) with your ML analysis notebook.
 - In order to add the notebook to the automated Kubeflow workflow, follow instructions in the [guide](automating-using-elyra.md).

--- a/notebooks/data-sources/TestGrid/metrics/blocked_timed_out.ipynb
+++ b/notebooks/data-sources/TestGrid/metrics/blocked_timed_out.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "lined-blake",
+   "id": "7ebcfcf8",
    "metadata": {},
    "source": [
     "# Tests Blocked and Timed Out Tests\n",
@@ -18,7 +18,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "several-judgment",
+   "id": "94a24a6a",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T16:44:12.972187Z",
@@ -55,7 +55,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "contemporary-intersection",
+   "id": "273158c3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -75,7 +75,7 @@
     "s3_access_key = os.getenv(\"S3_ACCESS_KEY\")\n",
     "s3_secret_key = os.getenv(\"S3_SECRET_KEY\")\n",
     "s3_bucket = os.getenv(\"S3_BUCKET\")\n",
-    "s3_path = os.getenv(\"S3_PROJECT_KEY\", \"metrics\")\n",
+    "s3_path = os.getenv(\"S3_PROJECT_KEY\", \"ai4ci/testgrid/metrics\")\n",
     "s3_input_data_path = \"raw_data\"\n",
     "AUTOMATION = os.getenv(\"IN_AUTOMATION\")"
    ]
@@ -83,7 +83,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "prerequisite-familiar",
+   "id": "4ffb2586",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -106,7 +106,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "medieval-shield",
+   "id": "78a8c502",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T16:44:27.621017Z",
@@ -121,7 +121,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "constitutional-middle",
+   "id": "af9059b9",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T16:44:55.758887Z",
@@ -136,7 +136,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "designing-fundamentals",
+   "id": "c77fa35e",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T16:44:55.765711Z",
@@ -162,7 +162,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "governmental-information",
+   "id": "a199b214",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T16:44:55.775074Z",
@@ -193,7 +193,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "comparative-settle",
+   "id": "f6c6587b",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T16:44:56.327631Z",
@@ -319,7 +319,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "intermediate-gravity",
+   "id": "2233ef0a",
    "metadata": {},
    "source": [
     "* **Timed Out Tests** : Finding all the tests that are timed out i.e. tests with the status code 9."
@@ -328,7 +328,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "stock-pontiac",
+   "id": "d3e28dcd",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T16:45:26.742323Z",
@@ -343,7 +343,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "coordinate-corps",
+   "id": "5eb0ab73",
    "metadata": {},
    "outputs": [
     {
@@ -364,7 +364,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "occupied-proof",
+   "id": "2efacaca",
    "metadata": {},
    "outputs": [
     {
@@ -390,7 +390,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "desirable-masters",
+   "id": "ab166e47",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T16:45:27.269559Z",
@@ -517,7 +517,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "funny-going",
+   "id": "12454df0",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T16:45:27.525281Z",
@@ -557,7 +557,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "rubber-bedroom",
+   "id": "807474e1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -571,7 +571,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "ahead-spread",
+   "id": "f612d9c7",
    "metadata": {},
    "outputs": [
     {
@@ -688,7 +688,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "simplified-migration",
+   "id": "38ec61e3",
    "metadata": {},
    "source": [
     "## Save to Ceph or Local"
@@ -697,7 +697,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "major-string",
+   "id": "13f90199",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -719,7 +719,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "found-carol",
+   "id": "7e9f5af0",
    "metadata": {},
    "outputs": [
     {
@@ -935,7 +935,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "matched-testament",
+   "id": "5924695c",
    "metadata": {},
    "source": [
     "## Conclusion :\n",

--- a/notebooks/data-sources/TestGrid/metrics/build_pass_failure.ipynb
+++ b/notebooks/data-sources/TestGrid/metrics/build_pass_failure.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "fecfd2b8",
+   "id": "cbb9bc12",
    "metadata": {},
    "source": [
     "# Quantify Build Pass/Failure\n",
@@ -21,7 +21,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "9992d52a",
+   "id": "fc8ee7f1",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T19:16:52.176485Z",
@@ -60,7 +60,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "768fad01",
+   "id": "719494fd",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T19:17:05.930968Z",
@@ -85,7 +85,7 @@
     "s3_access_key = os.getenv(\"S3_ACCESS_KEY\")\n",
     "s3_secret_key = os.getenv(\"S3_SECRET_KEY\")\n",
     "s3_bucket = os.getenv(\"S3_BUCKET\")\n",
-    "s3_path = os.getenv(\"S3_PROJECT_KEY\", \"metrics\")\n",
+    "s3_path = os.getenv(\"S3_PROJECT_KEY\", \"ai4ci/testgrid/metrics\")\n",
     "s3_input_data_path = \"raw_data\"\n",
     "AUTOMATION = os.getenv(\"IN_AUTOMATION\")"
    ]
@@ -93,7 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "efdc1ffb",
+   "id": "dbd2c3be",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5ccd743f",
+   "id": "c9dd3f41",
    "metadata": {},
    "source": [
     "## Metric Calculation\n",
@@ -124,7 +124,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "4fded597",
+   "id": "582f59b4",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T19:17:32.122674Z",
@@ -139,7 +139,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "eae77ba8",
+   "id": "01eb4340",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T19:17:32.129481Z",
@@ -165,7 +165,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "7251a383",
+   "id": "948655b4",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T19:17:33.357274Z",
@@ -196,7 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "fb3883a9",
+   "id": "08382997",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T19:17:48.514257Z",
@@ -215,7 +215,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "068f64d5",
+   "id": "b08199a6",
    "metadata": {},
    "source": [
     "We use the `Overall` tests as our proxy for builds. We used the labels provided by TestGrid which classify a test overall as Pass or Fail to indicate build success and failures."
@@ -224,7 +224,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "aba56c6d",
+   "id": "f3246b10",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T19:17:49.995766Z",
@@ -239,7 +239,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "61a36330",
+   "id": "f0ca8b98",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T19:17:50.011468Z",
@@ -347,7 +347,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e89346ef",
+   "id": "81216a8c",
    "metadata": {},
    "source": [
     "We now find all the tests which are passing i.e. have a status code of 1."
@@ -356,7 +356,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "f4c07f3d",
+   "id": "2dbcccde",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T19:18:28.411187Z",
@@ -371,7 +371,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "cb98a035",
+   "id": "5af42eaf",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T19:18:41.892913Z",
@@ -391,7 +391,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "8daeca7d",
+   "id": "004054c5",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T19:18:43.335390Z",
@@ -406,7 +406,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "9d92b3e0",
+   "id": "5e1febbc",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T19:18:43.350415Z",
@@ -514,7 +514,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2527d77",
+   "id": "6dbbd60a",
    "metadata": {},
    "source": [
     "## Metric Calculation\n",
@@ -524,7 +524,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "8eb70e62",
+   "id": "4441ac91",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T19:18:43.681329Z",
@@ -564,7 +564,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "896964c4",
+   "id": "392723c0",
    "metadata": {},
    "source": [
     "## Visualization\n",
@@ -574,7 +574,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "b08abd9a",
+   "id": "fe1c2f02",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T19:18:43.691673Z",
@@ -603,7 +603,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "e9e7770d",
+   "id": "f85f586f",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T19:18:47.084942Z",
@@ -622,7 +622,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "24bb7949",
+   "id": "606b2b49",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T19:18:49.393295Z",
@@ -819,7 +819,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "4d4e6880",
+   "id": "b9254276",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T19:18:49.690384Z",
@@ -839,7 +839,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "12e2b089",
+   "id": "21534155",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T19:18:52.697496Z",
@@ -854,7 +854,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "c3a9faec",
+   "id": "048f874b",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T19:18:53.513997Z",
@@ -982,7 +982,7 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "77824edf",
+   "id": "b95c3d63",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T19:18:55.604953Z",
@@ -1008,7 +1008,7 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "94264655",
+   "id": "1bc650da",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T19:18:56.127417Z",
@@ -1024,7 +1024,7 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "9ac159f4",
+   "id": "def24f0e",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T19:18:56.660232Z",
@@ -1050,7 +1050,7 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "0df58396",
+   "id": "4fee535d",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T19:18:57.605148Z",
@@ -1080,7 +1080,7 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "04c9ceb0",
+   "id": "572080c5",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T19:18:58.055919Z",
@@ -1110,7 +1110,7 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "b3772261",
+   "id": "bfb43c6a",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T19:18:59.505261Z",
@@ -1136,7 +1136,7 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "d45ea169",
+   "id": "44d037b0",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-24T19:19:00.943626Z",
@@ -1165,7 +1165,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e1830d56",
+   "id": "3489fda7",
    "metadata": {},
    "source": [
     "## Save to Ceph or local"
@@ -1174,7 +1174,7 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "55e97577",
+   "id": "af1990c8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1198,7 +1198,7 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "7148794c",
+   "id": "5cba2777",
    "metadata": {},
    "outputs": [
     {
@@ -1413,7 +1413,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fbd7588d",
+   "id": "73ce6386",
    "metadata": {},
    "source": [
     "### Conclusion\n",

--- a/notebooks/data-sources/TestGrid/metrics/correlated_failures.ipynb
+++ b/notebooks/data-sources/TestGrid/metrics/correlated_failures.ipynb
@@ -74,7 +74,7 @@
     "s3_access_key = os.getenv(\"S3_ACCESS_KEY\")\n",
     "s3_secret_key = os.getenv(\"S3_SECRET_KEY\")\n",
     "s3_bucket = os.getenv(\"S3_BUCKET\")\n",
-    "s3_path = os.getenv(\"S3_PROJECT_KEY\", \"metrics\")\n",
+    "s3_path = os.getenv(\"S3_PROJECT_KEY\", \"ai4ci/testgrid/metrics\")\n",
     "s3_input_data_path = \"raw_data\"\n",
     "AUTOMATION = os.getenv(\"IN_AUTOMATION\")"
    ]

--- a/notebooks/data-sources/TestGrid/metrics/metric_template.ipynb
+++ b/notebooks/data-sources/TestGrid/metrics/metric_template.ipynb
@@ -91,7 +91,7 @@
     "s3_access_key = os.getenv(\"S3_ACCESS_KEY\")\n",
     "s3_secret_key = os.getenv(\"S3_SECRET_KEY\")\n",
     "s3_bucket = os.getenv(\"S3_BUCKET\")\n",
-    "s3_path = os.getenv(\"S3_PROJECT_KEY\", \"metrics\")\n",
+    "s3_path = os.getenv(\"S3_PROJECT_KEY\", \"ai4ci/testgrid/metrics\")\n",
     "s3_input_data_path = \"raw_data\"\n",
     "\n",
     "# Specify whether or not we are running this as a notebook or part of an automation pipeline.\n",
@@ -952,13 +952,6 @@
     "### _Example Conclusion_ \n",
     "_This notebook computed number of flakes and the flake severity metric. The dataframe saved on ceph can be used to generate aggregated views and visualizations._"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/data-sources/TestGrid/metrics/metric_visualization_generic.ipynb
+++ b/notebooks/data-sources/TestGrid/metrics/metric_visualization_generic.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "52ac96fc-a792-4611-bc6e-29691ecd7a6e",
+   "id": "3074584c",
    "metadata": {},
    "source": [
     "# KPI Metrics Visualization\n",
@@ -17,7 +17,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "f366d4ae-04e4-4189-80c2-1b91d1235da0",
+   "id": "fe99aa35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -40,7 +40,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "7b597fae-02ca-4c24-855b-33dfdff4b707",
+   "id": "08852bf6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,7 +53,7 @@
     "s3_access_key = os.getenv(\"S3_ACCESS_KEY\")\n",
     "s3_secret_key = os.getenv(\"S3_SECRET_KEY\")\n",
     "s3_bucket = os.getenv(\"S3_BUCKET\")\n",
-    "s3_path = os.getenv(\"S3_PROJECT_KEY\")\n",
+    "s3_path = os.getenv(\"S3_PROJECT_KEY\", \"ai4ci/testgrid/metrics\")\n",
     "\n",
     "# Specify whether or not we are running this as a notebook or part of an automation pipeline.\n",
     "AUTOMATION = os.getenv(\"IN_AUTOMATION\")"
@@ -61,7 +61,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6d5c21dd-9ff4-4c82-a066-ee5f50f0ecf2",
+   "id": "cac27728",
    "metadata": {},
    "source": [
     "## Ceph Connection\n",
@@ -71,7 +71,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "4bd41fab-a878-4c88-9638-59a99d3fb10d",
+   "id": "bfdb56cf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,7 +89,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c2bec57a-9a43-428c-9584-3472ae989074",
+   "id": "b4694386",
    "metadata": {},
    "source": [
     "## Get KPI Data"
@@ -98,7 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "52c750a1-1123-442e-aa61-bf043c9ce007",
+   "id": "51812a33",
    "metadata": {},
    "outputs": [
     {
@@ -136,7 +136,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "8f3c6a46-9765-4558-b816-3f13f7c522e9",
+   "id": "6ed5ca64",
    "metadata": {},
    "outputs": [
     {
@@ -172,7 +172,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49956718-e77f-42b8-ae65-49ddeaded9c7",
+   "id": "751c6648",
    "metadata": {},
    "source": [
     "## Helper Function for Plotting"
@@ -181,7 +181,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "848e2f71-e6cd-44d6-8cc2-21a15fba8dce",
+   "id": "16ca74a2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -200,7 +200,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8a91c54b-d0ea-454e-806f-ce0c7a0a62a8",
+   "id": "02a89645",
    "metadata": {},
    "source": [
     "## Visualize KPIs\n",
@@ -209,7 +209,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b187142a-5dcc-417a-a4a6-d09d80cfddcb",
+   "id": "8fadfd83",
    "metadata": {},
    "source": [
     "### Blocked Timed Out\n",
@@ -219,7 +219,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "36f06ab9-4dbc-4bf2-adb6-445803d7ab29",
+   "id": "07bda461",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -262,7 +262,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aaa82587-8af5-4bc2-be49-17ccd15bf0e6",
+   "id": "da5a72ae",
    "metadata": {},
    "source": [
     "Let's plot the following metrics from the `blocked_timed_out` KPI file:"
@@ -270,7 +270,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f47b41ac-0f9d-49ae-af87-eaa579e0401d",
+   "id": "141be744",
    "metadata": {},
    "source": [
     "#### Number of blocked tests\n",
@@ -280,7 +280,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "80e484f0-5ea0-4388-81a0-474ea780c9b7",
+   "id": "7603977c",
    "metadata": {},
    "outputs": [
     {
@@ -300,7 +300,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c8310ddb-06e8-4261-8de9-483fbc4be2c8",
+   "id": "97743a32",
    "metadata": {},
    "source": [
     "#### Blocked tests percentage\n",
@@ -310,7 +310,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "df0b76ca-6a3e-48e9-b847-db948df495bb",
+   "id": "685873e8",
    "metadata": {},
    "outputs": [
     {
@@ -332,7 +332,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ea779967-fece-4f54-8d68-cd4ef1908472",
+   "id": "b4887a62",
    "metadata": {},
    "source": [
     "#### Number of timed out tests\n",
@@ -342,7 +342,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "4e3dc3c3-a71c-43f5-b5e6-27a8c64656cc",
+   "id": "c5d618db",
    "metadata": {},
    "outputs": [
     {
@@ -362,7 +362,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d98fcb51-1768-47d3-a7c4-a90809969e95",
+   "id": "cd44fc16",
    "metadata": {},
    "source": [
     "#### Percentage of tests timed out\n",
@@ -372,7 +372,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "3ea54bad-52ac-47ff-8d99-d52701d8bb50",
+   "id": "cfea2306",
    "metadata": {},
    "outputs": [
     {
@@ -398,7 +398,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ed266cb5-ab62-443c-ba62-d5292c1cb298",
+   "id": "4adc03b5",
    "metadata": {},
    "source": [
     "From the above graphs, we see that there were no blocked tests or timed out tests found."
@@ -406,7 +406,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4ce05bfd-2b25-4def-98be-3aa52b88ff2c",
+   "id": "c8094955",
    "metadata": {},
    "source": [
     "### Build Pass Failure\n",
@@ -416,7 +416,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "387ee90c-1203-467c-b989-3d7a89badc3c",
+   "id": "2334f29b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -459,7 +459,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5e40e69f-dcf5-4151-bac3-56fab0f3e27a",
+   "id": "a5cfef14",
    "metadata": {},
    "source": [
     "Let's plot the following metrics from the `build_pass_failure` KPI file:"
@@ -467,7 +467,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2190f88c-bc28-4b30-890a-d5f1851d0450",
+   "id": "4f7b4e05",
    "metadata": {},
    "source": [
     "#### Number of builds passed\n",
@@ -477,7 +477,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "02e9948c-36ac-43b0-bb02-ee6a145299ee",
+   "id": "5b636aa2",
    "metadata": {},
    "outputs": [
     {
@@ -497,7 +497,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "af92a17d-287b-4606-849a-6f4afb99edf1",
+   "id": "9e10cb7d",
    "metadata": {},
    "source": [
     "#### Build pass percentage\n",
@@ -507,7 +507,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "f2ea5476-f568-49e2-b288-10516399db51",
+   "id": "b4637558",
    "metadata": {},
    "outputs": [
     {
@@ -533,7 +533,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1b1f0dd4-333b-4d6a-8cd7-18bf7bc61d7c",
+   "id": "2ecab1a3",
    "metadata": {},
    "source": [
     "From the above graphs, we see that on an average about ~50% of builds pass."
@@ -541,7 +541,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "81e38a4c-6f7b-41a3-afba-9c60cf2cf522",
+   "id": "fd1394d1",
    "metadata": {},
    "source": [
     "#### Number of build failures\n",
@@ -551,7 +551,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "7f688261-0c86-4018-81a0-b7af3d9b4d41",
+   "id": "09823181",
    "metadata": {},
    "outputs": [
     {
@@ -571,7 +571,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22577e62-6841-4217-a129-c8e2115b2ad7",
+   "id": "fd8f6d95",
    "metadata": {},
    "source": [
     "#### Build failure percentage\n",
@@ -581,7 +581,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "8974890d-8d8f-47dc-8db7-31172d9b851a",
+   "id": "62f97e7c",
    "metadata": {},
    "outputs": [
     {
@@ -607,7 +607,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "de6d1d8e-15ee-4c71-84dc-8c6b9a39be7f",
+   "id": "7770a338",
    "metadata": {},
    "source": [
     "From the above graphs we see that on an average about ~50% of builds fail i.e there is a 50-50 chance for a build to either pass or fail."
@@ -615,7 +615,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "802be8ce-3701-4148-ae8c-0309c47db51d",
+   "id": "2eff1a85",
    "metadata": {},
    "source": [
     "### Number of Flakes\n",
@@ -625,7 +625,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "ac496ba2-49c4-4ead-91ec-3b47eb16b691",
+   "id": "25a009be",
    "metadata": {},
    "outputs": [
     {
@@ -662,7 +662,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e1c7bc45-a026-4b41-ab1c-5c85c64d507d",
+   "id": "46bdc736",
    "metadata": {},
    "source": [
     "Lets plot the following metrics from the `number_of_flakes` KPI file:"
@@ -670,7 +670,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3eb74482-e6c2-4f78-9567-c640af9bd2dc",
+   "id": "fc071994",
    "metadata": {},
    "source": [
     "#### Number of flaky tests\n",
@@ -680,7 +680,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "b691e7f8-efe4-47f6-b4db-17d4bb8731ff",
+   "id": "a8a48bb1",
    "metadata": {},
    "outputs": [
     {
@@ -700,7 +700,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40184a7e-6e1d-4a7c-9858-112f39f47e3b",
+   "id": "15104b8b",
    "metadata": {},
    "source": [
     "#### Flake Severity\n",
@@ -710,7 +710,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "27edae53-b800-470e-9e0e-21b0ddd699fe",
+   "id": "96ed19bb",
    "metadata": {},
    "outputs": [
     {
@@ -730,7 +730,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cfee3967-a34d-4b70-8f2e-6229bf848e91",
+   "id": "ab5442f9",
    "metadata": {},
    "source": [
     "From the above graphs, we see that the number of flakes has increased over time and there were more \"flaky\" tests found."
@@ -738,7 +738,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ab061273-77c8-4ba6-83f8-5f5d0490b691",
+   "id": "8db469a6",
    "metadata": {},
    "source": [
     "### Percent Fixed each Timestamp\n",
@@ -748,7 +748,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "3aad28f2-2898-49ea-b3b3-3eba82c89f88",
+   "id": "d6592e2f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -777,7 +777,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9d396842-2b68-413a-b240-068c1896de23",
+   "id": "60c23ed4",
    "metadata": {},
    "source": [
     "Let's plot the following metric for the `pct_fixed_each_ts` KPI file:"
@@ -785,7 +785,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12138269-e553-46cf-8a8b-ec2e081110ab",
+   "id": "fab8296c",
    "metadata": {},
    "source": [
     "#### Percent of Tests Fixed\n",
@@ -795,7 +795,7 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "83624909-09c6-4ea2-99ce-014b5222fb4b",
+   "id": "8b47aa12",
    "metadata": {},
    "outputs": [
     {
@@ -815,7 +815,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0705e988-4c15-42c2-83c9-c54dd9b9dfaf",
+   "id": "25cb7d51",
    "metadata": {},
    "source": [
     "From the above graph, we see that the percentage of tests fixed has increased over time which is a good indication of more tests passing over time."
@@ -823,7 +823,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2c7542f3-2036-440c-b469-d61b40dd0446",
+   "id": "2c1d1793",
    "metadata": {},
    "source": [
     "### Persistent Failures\n",
@@ -833,7 +833,7 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "2b83eb9c-d6ad-45f9-84e6-7ee36286dc86",
+   "id": "93655a0e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -880,7 +880,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aa81b037-5d00-4ff8-b475-bc5dd93ccb5b",
+   "id": "e6cd314c",
    "metadata": {},
    "source": [
     "Lets plot the metrics from the `persistent_failures` KPI file:"
@@ -888,7 +888,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4d5d6063-106a-48d7-942a-062bdf26a07d",
+   "id": "29be7dad",
    "metadata": {},
    "source": [
     "#### Mean Length of Failures\n",
@@ -898,7 +898,7 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "a1bacbc7-9cb0-4824-8220-ddaf61adc422",
+   "id": "64535b76",
    "metadata": {},
    "outputs": [
     {
@@ -924,7 +924,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0e93d347-98f8-41d5-8e27-a25b2a029479",
+   "id": "e7d057f4",
    "metadata": {},
    "source": [
     "#### Mean Time to Fix\n",
@@ -934,7 +934,7 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "554070eb-0497-46b8-bacd-2518b5b49491",
+   "id": "0128a644",
    "metadata": {},
    "outputs": [
     {
@@ -960,7 +960,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bd203372-63e1-4de0-ab0b-0a57b79e24cd",
+   "id": "b09ed3f4",
    "metadata": {},
    "source": [
     "From the above graph, we see that the mean time to fix on an average has reduced over time i.e lesser time is being taken before a failing test starts to pass."
@@ -968,7 +968,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7578634b-9258-4801-97b6-b0e8023ab4c2",
+   "id": "b9aabdf0",
    "metadata": {},
    "source": [
     "#### Consecutive Failure Rate\n",
@@ -978,7 +978,7 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "59360c2c-54d0-4add-8abc-b092dddb1478",
+   "id": "e2d294da",
    "metadata": {},
    "outputs": [
     {
@@ -1004,7 +1004,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c01c5f56-c8f6-4b97-b80b-1d34ebb6bc91",
+   "id": "a2cf2d75",
    "metadata": {},
    "source": [
     "From the above graph we see that the consecutive failure rate is on an average ~0.0125. "
@@ -1012,7 +1012,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "592fc8f8-bd00-4fea-92f6-0586ad0a30d9",
+   "id": "0a40d09c",
    "metadata": {},
    "source": [
     "#### Pass to Fail Rate\n",
@@ -1022,7 +1022,7 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "548f4b09-9349-4c08-aa6d-73a160999840",
+   "id": "49663ac4",
    "metadata": {},
    "outputs": [
     {
@@ -1042,7 +1042,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0279aaca-13b5-43f3-be08-c7e906f0f100",
+   "id": "0e7e76d4",
    "metadata": {},
    "source": [
     "From the above graph, we see that the pass to fail rate for tests has not been consistent."
@@ -1050,7 +1050,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e492cca6-c2e3-4059-b992-4e96cc36e9fc",
+   "id": "2b4efe67",
    "metadata": {},
    "source": [
     "#### Fail to Pass Rate\n",
@@ -1060,7 +1060,7 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "17dbf8d4-42fc-4919-9b21-e27a95c83d13",
+   "id": "32a9aa4d",
    "metadata": {},
    "outputs": [
     {
@@ -1080,7 +1080,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8760530b-bd49-4350-81d9-d33dad6c1a80",
+   "id": "fb09cf58",
    "metadata": {},
    "source": [
     "Similary, the fail to pass rate for tests has also been inconsistent."
@@ -1088,7 +1088,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5ea48833-1399-4c75-b9ed-6a0936645cb0",
+   "id": "70538b15",
    "metadata": {},
    "source": [
     "### Test Pass Failures\n",
@@ -1098,7 +1098,7 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "c78990aa-352e-419c-a61f-c200246e2278",
+   "id": "cb7bc9e8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1141,7 +1141,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ae7b38b1-42cf-4330-8b47-e48ec1149a14",
+   "id": "67b8483c",
    "metadata": {},
    "source": [
     "Lets plot the following metrics from the `test_pass_failures` KPI file:"
@@ -1149,7 +1149,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "642065b8-dd61-4eb3-a2eb-1c012c9028ec",
+   "id": "30226dc5",
    "metadata": {},
    "source": [
     "#### Number of passing tests\n",
@@ -1159,7 +1159,7 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "b8c06e42-d112-4fe7-981b-84dd2dffe09a",
+   "id": "797a8601",
    "metadata": {},
    "outputs": [
     {
@@ -1179,7 +1179,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e27b80eb-4f41-4e99-bbb1-9d046645fa8a",
+   "id": "29ca63cf",
    "metadata": {},
    "source": [
     "#### Test pass percentage\n",
@@ -1189,7 +1189,7 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "id": "0f6c95f6-06c6-43ef-a0e7-52604b23b929",
+   "id": "3d8697ac",
    "metadata": {},
    "outputs": [
     {
@@ -1209,7 +1209,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ce8c7b68-32ef-4a87-abf2-c34a916807c4",
+   "id": "85a20dbf",
    "metadata": {},
    "source": [
     "#### Number of failing tests\n",
@@ -1219,7 +1219,7 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "id": "abfdf1df-bd1a-4510-b19c-6750c94f5b9a",
+   "id": "cf71d11d",
    "metadata": {},
    "outputs": [
     {
@@ -1239,7 +1239,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7bd6a784-f4c0-4f95-8c81-ec78635d8988",
+   "id": "27c50c3d",
    "metadata": {},
    "source": [
     "#### Test failure percentage\n",
@@ -1249,7 +1249,7 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "id": "1def6cdc-cbce-41f2-9c0d-c92ddaef84cd",
+   "id": "08b61188",
    "metadata": {},
    "outputs": [
     {
@@ -1275,7 +1275,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc487d2d-ab30-40d2-8f4e-01a8fa74e305",
+   "id": "840d7ec1",
    "metadata": {},
    "source": [
     "From the above graphs, we see that overall there has been an increase in the number of tests failing daily, however this increase is low i.e ~3000-7000 compared to the number of tests passing daily i.e. ~70000-95000."
@@ -1283,7 +1283,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ed348f50-3483-4f71-80f8-256a657bdcf1",
+   "id": "b9b0f5e2",
    "metadata": {},
    "source": [
     "### Time to Test\n",
@@ -1293,7 +1293,7 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "id": "f4f59003-4ace-44ff-890f-237e23546bcd",
+   "id": "6ccb916f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1322,7 +1322,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f8dd3847-1d9e-4e34-bf0b-18f7939a607f",
+   "id": "d511dbed",
    "metadata": {},
    "source": [
     "Let's plot the following metric from the `time_to_test` KPI file:"
@@ -1330,7 +1330,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48706f7c-5d5f-4dc1-a304-f2695c19ef1e",
+   "id": "6b4127ee",
    "metadata": {},
    "source": [
     "#### Average Time to Test\n",
@@ -1340,7 +1340,7 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "id": "91ed6e75-0e32-456c-95fc-335c85435b24",
+   "id": "178503da",
    "metadata": {},
    "outputs": [
     {
@@ -1360,7 +1360,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4c04a9d-678b-49d8-94a7-ad14b32266f0",
+   "id": "8cf7e679",
    "metadata": {},
    "source": [
     "From the above graph, we see that the average test duration has slightly increased over time and been in the range of ~85-89 minutes."
@@ -1368,7 +1368,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "342cf0ca-5e07-4a4d-9915-5857f3e52bd0",
+   "id": "fc23fd6e",
    "metadata": {},
    "source": [
     "## Conclusion\n",

--- a/notebooks/data-sources/TestGrid/metrics/metrics_visualization.ipynb
+++ b/notebooks/data-sources/TestGrid/metrics/metrics_visualization.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "390df1fc",
+   "id": "700e3682",
    "metadata": {},
    "source": [
     "# KPI Metrics Visualization\n",
@@ -21,7 +21,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "b2afcf84",
+   "id": "02f9e6a4",
    "metadata": {
     "code_folding": []
    },
@@ -46,7 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "459d397a",
+   "id": "8d83012b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,7 +59,7 @@
     "s3_access_key = os.getenv(\"S3_ACCESS_KEY\")\n",
     "s3_secret_key = os.getenv(\"S3_SECRET_KEY\")\n",
     "s3_bucket = os.getenv(\"S3_BUCKET\")\n",
-    "s3_path = os.getenv(\"S3_PROJECT_KEY\")\n",
+    "s3_path = os.getenv(\"S3_PROJECT_KEY\", \"ai4ci/testgrid/metrics\")\n",
     "\n",
     "# Specify whether or not we are running this as a notebook or part of an automation pipeline.\n",
     "AUTOMATION = os.getenv(\"IN_AUTOMATION\")"
@@ -68,7 +68,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "6a597417",
+   "id": "897463b1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,7 +86,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ec24c6bd",
+   "id": "57282d75",
    "metadata": {},
    "source": [
     "## Helper functions"
@@ -95,7 +95,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "483ce9de",
+   "id": "e3e02ff5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,7 +152,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "f0732b37",
+   "id": "390f2f55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -185,7 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "d7ec50ed",
+   "id": "ee56ace0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -210,7 +210,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "2e04ee0c",
+   "id": "6b4e2f4b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -244,7 +244,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "6cafa539",
+   "id": "956cdaba",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -273,7 +273,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f2b5c9cd",
+   "id": "b016f5ac",
    "metadata": {},
    "source": [
     "## Get KPI Data\n",
@@ -283,7 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "b0b9086d",
+   "id": "0e96a1b7",
    "metadata": {
     "code_folding": [
      0
@@ -400,7 +400,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8e728a7c",
+   "id": "183c93d3",
    "metadata": {},
    "source": [
     "**NOTE** The following kpi file / metric / date selection process is a bit restricted right now since ipywidgets are currently unavailable, but should be more interactive once that issue is resolved."
@@ -409,7 +409,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "8da35e7f",
+   "id": "4490b846",
    "metadata": {},
    "outputs": [
     {
@@ -469,7 +469,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "1914ff62",
+   "id": "2700c937",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -480,7 +480,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "e61c5e2e",
+   "id": "3c7f464f",
    "metadata": {},
    "outputs": [
     {
@@ -507,7 +507,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "bfbc5272",
+   "id": "a97f4169",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -518,7 +518,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "d2dd1813",
+   "id": "5ac6b43f",
    "metadata": {},
    "outputs": [
     {
@@ -637,7 +637,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "430f6697",
+   "id": "2263c311",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -646,7 +646,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2970804b",
+   "id": "53baa0ca",
    "metadata": {},
    "source": [
     "### Get all KPIs for the selected dashboard, job pair\n",
@@ -655,7 +655,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "db877984",
+   "id": "8a8da826",
    "metadata": {},
    "source": [
     "**NOTE** Some kpi files have no data for the given dashboard/job. e.g. for \"redhat-openshift-ocp-release-4.2-informing\", \"periodic-ci-openshift-release-master-ci-4.2-e2e-gcp\", blocked_time_out and test_pass_failure has no data (keys dont exist) and pct_fixed has all nan values."
@@ -664,7 +664,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "006314d2",
+   "id": "0eb68094",
    "metadata": {},
    "outputs": [
     {
@@ -687,7 +687,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "eecb3321",
+   "id": "573cd5c7",
    "metadata": {},
    "outputs": [
     {
@@ -918,7 +918,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a017bce3",
+   "id": "dec44706",
    "metadata": {},
    "source": [
     "## KPIs for the selected dashboard, job\n",
@@ -927,7 +927,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f7ae415c",
+   "id": "00c4675c",
    "metadata": {},
    "source": [
     "### Percent of passing and failing tests\n",
@@ -937,7 +937,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "03e39c17",
+   "id": "4e0c323b",
    "metadata": {},
    "outputs": [
     {
@@ -1169,7 +1169,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3cbaca10",
+   "id": "0fc21cba",
    "metadata": {},
    "source": [
     "There are 5334 total tests out of which we have True/False values for the `passing` and `failure` columns only for 1743 tests, the remaining are all NaN values. We will visualize the metrics only for these 1743 tests."
@@ -1177,7 +1177,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0eda34d9",
+   "id": "1b78a11c",
    "metadata": {},
    "source": [
     "#### Number of Test Passes"
@@ -1186,7 +1186,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "cb0fb678",
+   "id": "44c1ba8e",
    "metadata": {},
    "outputs": [
     {
@@ -1210,7 +1210,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "b9ec89ad",
+   "id": "c5ae3722",
    "metadata": {},
    "outputs": [
     {
@@ -1231,7 +1231,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c4843d29",
+   "id": "8b7735c5",
    "metadata": {},
    "source": [
     "#### Number of Test Failures"
@@ -1240,7 +1240,7 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "a5f7f97a",
+   "id": "5caaf1dc",
    "metadata": {},
    "outputs": [
     {
@@ -1264,7 +1264,7 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "95255ca6",
+   "id": "56db16ea",
    "metadata": {},
    "outputs": [
     {
@@ -1285,7 +1285,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7c3b2f5b",
+   "id": "97ff10db",
    "metadata": {},
    "source": [
     "#### Test Pass and Test Failure Percentage"
@@ -1294,7 +1294,7 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "d63450e1",
+   "id": "cccc28d9",
    "metadata": {},
    "outputs": [
     {
@@ -1316,7 +1316,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c10b8148",
+   "id": "ae30ca6d",
    "metadata": {},
    "source": [
     "Now, lets plot a bar plot for the same"
@@ -1325,7 +1325,7 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "3750e156",
+   "id": "f5c434a6",
    "metadata": {},
    "outputs": [
     {
@@ -1351,7 +1351,7 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "6c631758",
+   "id": "97169511",
    "metadata": {},
    "outputs": [
     {
@@ -1376,7 +1376,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "73e1fe86",
+   "id": "873a1c60",
    "metadata": {},
    "source": [
     "From the above graphs, we see that the total number of test passes that were successful was ~1200 and the number of tests that failed was about ~8. It is also important to note that if a test did not pass successfully, it does not neccessarily mean that it \"failed\", its possible that the test could be attributed to other status values such as those mentioned in https://github.com/aicoe-aiops/ocp-ci-analysis/blob/master/docs/cell_labels_in_testgrid.md.\n",
@@ -1386,7 +1386,7 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "32baa6e3",
+   "id": "c6f9babc",
    "metadata": {},
    "outputs": [
     {
@@ -1415,7 +1415,7 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "ed8b1899",
+   "id": "491bb821",
    "metadata": {},
    "outputs": [
     {
@@ -1442,7 +1442,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7e0a9cb7",
+   "id": "0dac621e",
    "metadata": {},
    "source": [
     "### Persistent Failures\n",
@@ -1451,7 +1451,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8a38f0ba",
+   "id": "b5a09250",
    "metadata": {},
    "source": [
     "#### Consecutive Failure Rate"
@@ -1460,7 +1460,7 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "8de66538",
+   "id": "3700c89e",
    "metadata": {},
    "outputs": [
     {
@@ -1492,7 +1492,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1b4f6be1",
+   "id": "e7816fd0",
    "metadata": {},
    "source": [
     "From the above graph, it seems like on that particular day i.e. \"2021-5-18\", there were no consecutive failures among the tests."
@@ -1500,7 +1500,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "97187361",
+   "id": "101e3bac",
    "metadata": {},
    "source": [
     "#### Pass to Fail Rate"
@@ -1509,7 +1509,7 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "48968726",
+   "id": "6b46ae17",
    "metadata": {},
    "outputs": [
     {
@@ -1541,7 +1541,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b9efe1a4",
+   "id": "3488cbeb",
    "metadata": {},
    "source": [
     "#### Fail to Pass Rate"
@@ -1550,7 +1550,7 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "id": "de0e380b",
+   "id": "98d27816",
    "metadata": {},
    "outputs": [
     {
@@ -1582,7 +1582,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8e899c9b",
+   "id": "2c3c78c5",
    "metadata": {},
    "source": [
     "#### Mean Time to Fix"
@@ -1591,7 +1591,7 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "id": "fb34efc9",
+   "id": "e2b30891",
    "metadata": {},
    "outputs": [
     {
@@ -1623,7 +1623,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6fb4af2b",
+   "id": "ae038cfe",
    "metadata": {},
    "source": [
     "### Time to Test\n",
@@ -1633,7 +1633,7 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "id": "c4d9db2b",
+   "id": "9e67b603",
    "metadata": {},
    "outputs": [
     {
@@ -1659,7 +1659,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f99498b4",
+   "id": "160a1301",
    "metadata": {},
    "source": [
     "In the above graph, we see how the time taken to run a build changes over time and we notice when there are spikes or when irregular builds occur."
@@ -1667,7 +1667,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bbae3a2e-d43c-47de-9272-a0c60cfe1add",
+   "id": "17deb63f",
    "metadata": {},
    "source": [
     "#### Average Time to Test\n",
@@ -1677,7 +1677,7 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "id": "b5e3d392-c33d-48bf-9087-8740e545d370",
+   "id": "0b243593",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1687,7 +1687,7 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "id": "5657dba8-e33d-452f-9d52-43d40ebd3b6a",
+   "id": "3d6c7b8e",
    "metadata": {},
    "outputs": [
     {
@@ -1791,7 +1791,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3e4bcb79-e336-490c-9869-f15d59a100d8",
+   "id": "1d7706e0",
    "metadata": {},
    "source": [
     "Now, lets plot the average test duration grouped by tests."
@@ -1800,7 +1800,7 @@
   {
    "cell_type": "code",
    "execution_count": 35,
-   "id": "ac990699-954b-4b49-b3c4-f49a8bf1d0b5",
+   "id": "60642706",
    "metadata": {},
    "outputs": [
     {
@@ -1824,7 +1824,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "abdcf4a6",
+   "id": "a350d605",
    "metadata": {},
    "source": [
     "From the above distribution plot, we see that for most of the tests took about ~88 minutes on an average to run the builds and there were a few which took a little longer, about ~100 minutes to run."
@@ -1832,7 +1832,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ab4c55c2",
+   "id": "40be9989",
    "metadata": {},
    "source": [
     "### Percent fixed\n",
@@ -1842,7 +1842,7 @@
   {
    "cell_type": "code",
    "execution_count": 36,
-   "id": "f1c9fe50",
+   "id": "d3b2368c",
    "metadata": {},
    "outputs": [
     {
@@ -1868,7 +1868,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "06ef8792",
+   "id": "c39204e2",
    "metadata": {},
    "source": [
     "From the above line graph, we see that the percent of fixed tests are quite low. This means that only a small percent of previously failing tests get fixed in each new run, which in turn implies that their CI process is likely not as efficient as it could be."
@@ -1876,7 +1876,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4cebae3b",
+   "id": "28874432",
    "metadata": {},
    "source": [
     "### Correlated failures\n",
@@ -1886,7 +1886,7 @@
   {
    "cell_type": "code",
    "execution_count": 37,
-   "id": "f706276c",
+   "id": "04e915f1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1910,7 +1910,7 @@
   {
    "cell_type": "code",
    "execution_count": 38,
-   "id": "3b3c4eee",
+   "id": "513e5ffa",
    "metadata": {},
    "outputs": [
     {
@@ -1939,7 +1939,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6bcb93a4",
+   "id": "7d327a9b",
    "metadata": {},
    "source": [
     "From the above line graph, we see that the average number of correlated failures vary quite drastically over time, from being as high as 7000 and having no correlated failures at all."
@@ -1948,7 +1948,7 @@
   {
    "cell_type": "code",
    "execution_count": 39,
-   "id": "361f3751",
+   "id": "dd11a6bf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1966,7 +1966,7 @@
   {
    "cell_type": "code",
    "execution_count": 40,
-   "id": "23f20009",
+   "id": "e07a151b",
    "metadata": {},
    "outputs": [
     {
@@ -1994,7 +1994,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "89490534",
+   "id": "471718ec",
    "metadata": {},
    "source": [
     "From the above box plot, we see that the mean number of correlated failures is about ~6000 and the maximum number of correlated failures observed on that day was about ~20000."
@@ -2002,7 +2002,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b652899e",
+   "id": "e1223834",
    "metadata": {},
    "source": [
     "### Blocked, Timed out\n",
@@ -2012,7 +2012,7 @@
   {
    "cell_type": "code",
    "execution_count": 41,
-   "id": "0b53f73a",
+   "id": "c9db9e75",
    "metadata": {},
    "outputs": [
     {
@@ -2035,7 +2035,7 @@
   {
    "cell_type": "code",
    "execution_count": 42,
-   "id": "acd545ef",
+   "id": "3e88b00d",
    "metadata": {},
    "outputs": [
     {
@@ -2058,7 +2058,7 @@
   {
    "cell_type": "code",
    "execution_count": 43,
-   "id": "2dd34c35",
+   "id": "c1760bd9",
    "metadata": {},
    "outputs": [
     {
@@ -2083,7 +2083,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ae935210",
+   "id": "b7e324c1",
    "metadata": {},
    "source": [
     "Here, we can conclude that the test_blocked and test_timed_out values are either unavailable for the data or are \"False\". "
@@ -2091,7 +2091,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eef4f055",
+   "id": "f0ccb089",
    "metadata": {},
    "source": [
     "### Build Pass Failure\n",
@@ -2100,7 +2100,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23ae1d89",
+   "id": "38964ab1",
    "metadata": {},
    "source": [
     "#### Number of builds passed"
@@ -2109,7 +2109,7 @@
   {
    "cell_type": "code",
    "execution_count": 44,
-   "id": "d94a060e",
+   "id": "79e7abf9",
    "metadata": {},
    "outputs": [
     {
@@ -2132,7 +2132,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "109b8e2c",
+   "id": "e78e0ded",
    "metadata": {},
    "source": [
     "#### Number of builds failed"
@@ -2141,7 +2141,7 @@
   {
    "cell_type": "code",
    "execution_count": 45,
-   "id": "d046ebab",
+   "id": "20789dcf",
    "metadata": {},
    "outputs": [
     {
@@ -2165,7 +2165,7 @@
   {
    "cell_type": "code",
    "execution_count": 46,
-   "id": "d62c4ba0",
+   "id": "fba329cd",
    "metadata": {},
    "outputs": [
     {
@@ -2200,7 +2200,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3b2c5871",
+   "id": "7badfd1f",
    "metadata": {},
    "source": [
     "For a given dashboard and job the build passing and failure are just the inverse of each other."
@@ -2208,7 +2208,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9edfd499",
+   "id": "12eace5d",
    "metadata": {},
    "source": [
     "### Number of flakes\n",
@@ -2218,7 +2218,7 @@
   {
    "cell_type": "code",
    "execution_count": 47,
-   "id": "44f67b2b",
+   "id": "f15d225c",
    "metadata": {},
    "outputs": [
     {
@@ -2347,7 +2347,7 @@
   {
    "cell_type": "code",
    "execution_count": 48,
-   "id": "fdb59ea7",
+   "id": "8ff7e438",
    "metadata": {},
    "outputs": [
     {
@@ -2419,7 +2419,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "665f9635",
+   "id": "9778c8de",
    "metadata": {},
    "source": [
     "#### Flake Severity"
@@ -2428,7 +2428,7 @@
   {
    "cell_type": "code",
    "execution_count": 49,
-   "id": "3422874e",
+   "id": "3421c9af",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2439,7 +2439,7 @@
   {
    "cell_type": "code",
    "execution_count": 50,
-   "id": "50b6783e",
+   "id": "ec6c1091",
    "metadata": {},
    "outputs": [
     {
@@ -2471,7 +2471,7 @@
   {
    "cell_type": "code",
    "execution_count": 51,
-   "id": "4b77a384",
+   "id": "36873856",
    "metadata": {},
    "outputs": [
     {
@@ -2494,7 +2494,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "708470ce",
+   "id": "2ada6a28",
    "metadata": {},
    "source": [
     "From the above graph we can conclude that most of the tests have very low(~0) flake severity. One might look at this graph and assume that almost all of the tests have flake severity as 0. So, to get more clarity we have plotted another graph limiting the count to 50."
@@ -2503,7 +2503,7 @@
   {
    "cell_type": "code",
    "execution_count": 52,
-   "id": "0304e9a4",
+   "id": "df170015",
    "metadata": {},
    "outputs": [
     {
@@ -2527,7 +2527,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fe2dd8bc",
+   "id": "9c02e66e",
    "metadata": {},
    "source": [
     "From the above graph we can see that there are other values of flake severity for some tests. However, it is a small bunch of tests that show a different set of flake severity."
@@ -2535,7 +2535,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d16d4f61",
+   "id": "202d0a1d",
    "metadata": {},
    "source": [
     "## Visualize KPIs for the different jobs under a given dashboard\n",
@@ -2546,7 +2546,7 @@
   {
    "cell_type": "code",
    "execution_count": 53,
-   "id": "88c59f8e",
+   "id": "33bc1b03",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2556,7 +2556,7 @@
   {
    "cell_type": "code",
    "execution_count": 54,
-   "id": "42cd581b",
+   "id": "1a65a623",
    "metadata": {},
    "outputs": [
     {
@@ -2590,7 +2590,7 @@
   {
    "cell_type": "code",
    "execution_count": 55,
-   "id": "e5752aea",
+   "id": "250bf640",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2600,7 +2600,7 @@
   {
    "cell_type": "code",
    "execution_count": 56,
-   "id": "a43bfd66",
+   "id": "00606218",
    "metadata": {},
    "outputs": [
     {
@@ -2623,7 +2623,7 @@
   {
    "cell_type": "code",
    "execution_count": 57,
-   "id": "a57c14d6",
+   "id": "554b052b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2636,7 +2636,7 @@
   {
    "cell_type": "code",
    "execution_count": 58,
-   "id": "981344c6",
+   "id": "c7a06db8",
    "metadata": {},
    "outputs": [
     {
@@ -2758,7 +2758,7 @@
   {
    "cell_type": "code",
    "execution_count": 59,
-   "id": "86f11c6a",
+   "id": "9362860a",
    "metadata": {},
    "outputs": [
     {
@@ -2820,7 +2820,7 @@
   {
    "cell_type": "code",
    "execution_count": 60,
-   "id": "a423254f",
+   "id": "127eafb9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2832,7 +2832,7 @@
   {
    "cell_type": "code",
    "execution_count": 61,
-   "id": "4c78921a",
+   "id": "ba20c8c1",
    "metadata": {},
    "outputs": [
     {
@@ -2902,7 +2902,7 @@
   {
    "cell_type": "code",
    "execution_count": 62,
-   "id": "df66e8fe",
+   "id": "2f2d0a37",
    "metadata": {},
    "outputs": [
     {
@@ -2971,7 +2971,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2b0ade00",
+   "id": "294ddf04",
    "metadata": {},
    "source": [
     "## Visualize the KPIs for different tests under a given job\n",
@@ -2982,7 +2982,7 @@
   {
    "cell_type": "code",
    "execution_count": 63,
-   "id": "a5589f76",
+   "id": "1b90adf8",
    "metadata": {},
    "outputs": [
     {
@@ -3009,7 +3009,7 @@
   {
    "cell_type": "code",
    "execution_count": 64,
-   "id": "bfb2fa77",
+   "id": "9bf00573",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3020,7 +3020,7 @@
   {
    "cell_type": "code",
    "execution_count": 65,
-   "id": "e3e58700",
+   "id": "f4ff5c64",
    "metadata": {},
    "outputs": [
     {
@@ -3139,7 +3139,7 @@
   {
    "cell_type": "code",
    "execution_count": 66,
-   "id": "1f408dac",
+   "id": "adeef327",
    "metadata": {},
    "outputs": [
     {
@@ -3165,7 +3165,7 @@
   {
    "cell_type": "code",
    "execution_count": 67,
-   "id": "68bf7d3f",
+   "id": "7061560e",
    "metadata": {},
    "outputs": [
     {
@@ -3194,7 +3194,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "04696d6c",
+   "id": "9325c708",
    "metadata": {},
    "source": [
     "**NOTE** The values for \"test_duration\" are only available for \"Overall\" hence the above graph shows only one lineplot with variation and rest all are overlapping at 80."
@@ -3202,7 +3202,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13887486",
+   "id": "63565355",
    "metadata": {},
    "source": [
     "## Conclusion\n",

--- a/notebooks/data-sources/TestGrid/metrics/number_of_flakes.ipynb
+++ b/notebooks/data-sources/TestGrid/metrics/number_of_flakes.ipynb
@@ -79,7 +79,7 @@
     "s3_secret_key = os.getenv(\"S3_SECRET_KEY\")\n",
     "s3_bucket = os.getenv(\"S3_BUCKET\")\n",
     "s3_input_data_path = \"raw_data\"\n",
-    "metric_path = f\"metrics/{METRIC_NAME}\""
+    "metric_path = f\"ai4ci/testgrid/metrics/{METRIC_NAME}\""
    ]
   },
   {

--- a/notebooks/data-sources/TestGrid/metrics/pct_fixed_each_ts.ipynb
+++ b/notebooks/data-sources/TestGrid/metrics/pct_fixed_each_ts.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "47e18006",
+   "id": "6dda7368",
    "metadata": {},
    "source": [
     "# Percent of Failing Tests Fixed\n",
@@ -19,7 +19,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "04911826",
+   "id": "2075a9a6",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-02-08T22:09:14.897443Z",
@@ -60,7 +60,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "5f9d0126",
+   "id": "d000b0da",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,7 +80,7 @@
     "s3_access_key = os.getenv(\"S3_ACCESS_KEY\")\n",
     "s3_secret_key = os.getenv(\"S3_SECRET_KEY\")\n",
     "s3_bucket = os.getenv(\"S3_BUCKET\")\n",
-    "s3_path = os.getenv(\"S3_PROJECT_KEY\", \"metrics\")\n",
+    "s3_path = os.getenv(\"S3_PROJECT_KEY\", \"ai4ci/testgrid/metrics\")\n",
     "s3_input_data_path = \"raw_data\"\n",
     "AUTOMATION = os.getenv(\"IN_AUTOMATION\")"
    ]
@@ -88,7 +88,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "aedbb023",
+   "id": "ef6c08d0",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-02-08T22:09:19.031967Z",
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1fe4fdb2",
+   "id": "0d40f118",
    "metadata": {},
    "source": [
     "## Calculation\n",
@@ -125,7 +125,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "dadcd884",
+   "id": "3b3d3ed1",
    "metadata": {},
    "outputs": [
     {
@@ -233,7 +233,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "209785cb",
+   "id": "0ba1989f",
    "metadata": {},
    "outputs": [
     {
@@ -258,7 +258,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "2b18badb",
+   "id": "0cb83fa7",
    "metadata": {},
    "outputs": [
     {
@@ -366,7 +366,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "1e5755d7",
+   "id": "41a167c1",
    "metadata": {},
    "outputs": [
     {
@@ -401,7 +401,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "2ad62825",
+   "id": "477bebca",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -411,7 +411,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "531bb47c",
+   "id": "9c69c765",
    "metadata": {},
    "outputs": [
     {
@@ -533,7 +533,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "dc8bcd2c",
+   "id": "4f9ace01",
    "metadata": {},
    "outputs": [
     {
@@ -568,7 +568,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "5f621fcb",
+   "id": "65ce22aa",
    "metadata": {},
    "outputs": [
     {
@@ -603,7 +603,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "19a46622",
+   "id": "2fa5df10",
    "metadata": {},
    "outputs": [
     {
@@ -772,7 +772,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7e81ab30",
+   "id": "2d819167",
    "metadata": {},
    "source": [
     "## Save to Ceph or local\n",
@@ -782,7 +782,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "45a2ba52",
+   "id": "f8225332",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -806,7 +806,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "d9d7e6d6",
+   "id": "640c2612",
    "metadata": {},
    "outputs": [
     {
@@ -922,7 +922,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dfb60ec6",
+   "id": "e9fc89bd",
    "metadata": {},
    "source": [
     "## Conclusion\n",

--- a/notebooks/data-sources/TestGrid/metrics/persistent_failures_analysis.ipynb
+++ b/notebooks/data-sources/TestGrid/metrics/persistent_failures_analysis.ipynb
@@ -78,7 +78,7 @@
     "s3_access_key = os.getenv(\"S3_ACCESS_KEY\")\n",
     "s3_secret_key = os.getenv(\"S3_SECRET_KEY\")\n",
     "s3_bucket = os.getenv(\"S3_BUCKET\")\n",
-    "s3_path = os.getenv(\"S3_PROJECT_KEY\", \"metrics\")\n",
+    "s3_path = os.getenv(\"S3_PROJECT_KEY\", \"ai4ci/testgrid/metrics\")\n",
     "s3_input_data_path = \"raw_data\"\n",
     "AUTOMATION = os.getenv(\"IN_AUTOMATION\")"
    ]

--- a/notebooks/data-sources/TestGrid/metrics/probability_to_fail.ipynb
+++ b/notebooks/data-sources/TestGrid/metrics/probability_to_fail.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "803c76ca",
+   "id": "f3c2cb4b",
    "metadata": {},
    "source": [
     "# Probability To Fail\n",
@@ -17,7 +17,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "ec7fd9d0",
+   "id": "9ad0ae80",
    "metadata": {},
    "outputs": [
     {
@@ -59,7 +59,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "4a2cfc22",
+   "id": "2dce36ca",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,7 +80,7 @@
     "s3_access_key = os.getenv(\"S3_ACCESS_KEY\")\n",
     "s3_secret_key = os.getenv(\"S3_SECRET_KEY\")\n",
     "s3_bucket = os.getenv(\"S3_BUCKET\")\n",
-    "s3_path = os.getenv(\"S3_PROJECT_KEY\", \"metrics\")\n",
+    "s3_path = os.getenv(\"S3_PROJECT_KEY\", \"ai4ci/testgrid/metrics\")\n",
     "s3_input_data_path = \"raw_data\"\n",
     "metric_path = f\"metrics/{METRIC_NAME}\""
    ]
@@ -88,7 +88,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "a0388fc5",
+   "id": "a5ec8f57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -109,7 +109,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ad17e80b",
+   "id": "0c3d718b",
    "metadata": {},
    "source": [
     "## Calculation"
@@ -118,7 +118,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "dabdb2fe",
+   "id": "c51ef525",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,7 +129,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "4d54563c",
+   "id": "9ab44c0e",
    "metadata": {},
    "outputs": [
     {
@@ -251,7 +251,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "2267efaa",
+   "id": "4a3981f9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -262,7 +262,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "9ca903ff",
+   "id": "809d6653",
    "metadata": {},
    "outputs": [
     {
@@ -384,7 +384,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "65523e5b",
+   "id": "b68325ec",
    "metadata": {},
    "outputs": [
     {
@@ -513,7 +513,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "4e3a74c7",
+   "id": "063f2bff",
    "metadata": {},
    "outputs": [
     {
@@ -533,7 +533,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "058f5684",
+   "id": "be514a81",
    "metadata": {},
    "source": [
     "### Calculate Probability to Fail using SVM and Calibrated Classification Model\n",
@@ -552,7 +552,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "5abe5553",
+   "id": "e37ae2ba",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -568,7 +568,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "48fc73e8",
+   "id": "b594a72c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -581,7 +581,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "5d016a6c",
+   "id": "eecbe5bd",
    "metadata": {},
    "outputs": [
     {
@@ -607,7 +607,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f656b427",
+   "id": "dbb03c02",
    "metadata": {},
    "source": [
     "#### Resampling the data\n",
@@ -618,7 +618,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6e4d3272",
+   "id": "169f7d99",
    "metadata": {},
    "source": [
     "Let's implement the basic method of undersampling and oversampling, which uses the `DataFrame.sample` method to get random samples of each class:"
@@ -627,7 +627,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "e785fba4",
+   "id": "ac703b42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -639,7 +639,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8bd6e6d7",
+   "id": "82d02f9c",
    "metadata": {},
    "source": [
     "##### Undersampling\n",
@@ -649,7 +649,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "442fbbc5",
+   "id": "63fddc1a",
    "metadata": {},
    "outputs": [
     {
@@ -698,7 +698,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7fd370d1",
+   "id": "480baa8f",
    "metadata": {},
    "source": [
     "##### Oversampling\n",
@@ -708,7 +708,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "82b85b27",
+   "id": "0cc5eea1",
    "metadata": {},
    "outputs": [
     {
@@ -757,7 +757,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e57b1df1",
+   "id": "80b09e52",
    "metadata": {},
    "source": [
     "#### SVM\n",
@@ -767,7 +767,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "31473909",
+   "id": "af94fe80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -798,7 +798,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9558cf76",
+   "id": "0164484e",
    "metadata": {},
    "source": [
     "*NOTE* : The probabilities are not normalized, but can be normalized when calling the `calibration_curve()` function by setting the `normalize` argument to `True`."
@@ -807,7 +807,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "fdd48010",
+   "id": "30f16507",
    "metadata": {},
    "outputs": [
     {
@@ -832,7 +832,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "da72470b",
+   "id": "ce82ef9b",
    "metadata": {},
    "source": [
     "Brier Score is a distance in the probability domain. Which means: the lower the value of this score, the better the prediction."
@@ -840,7 +840,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0ac18aa3",
+   "id": "65c86e13",
    "metadata": {},
    "source": [
     "The above calculated score is a harsh metric since we require for each sample that each label set be correctly predicted. This does not give us a clear indication of a better model so we will use the reliability diagram to find out the better suited model."
@@ -848,7 +848,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8ed6b649",
+   "id": "dec9b510",
    "metadata": {},
    "source": [
     "##### Reliability Diagram\n",
@@ -861,7 +861,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "821bae81",
+   "id": "0b05c577",
    "metadata": {},
    "outputs": [
     {
@@ -892,7 +892,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d92d2f64",
+   "id": "54d6bec5",
    "metadata": {},
    "source": [
     "In the above graph, the solid line represents the calibration of the SVMs predicted probabilities and the dotted line represents a comparison to a perfectly calibrated model. The better calibrated or more reliable a forecast, the closer the points will appear along the main diagonal from the bottom left to the top right of the plot. Here, we see that calibration probabilities are much further away from the ideal prediction.\n",
@@ -905,7 +905,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7761d74c",
+   "id": "f911f375",
    "metadata": {},
    "source": [
     "#### SVM for over sampled data"
@@ -914,7 +914,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "a007f4ef",
+   "id": "c61d72bc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -946,7 +946,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "e1037b89",
+   "id": "97239480",
    "metadata": {},
    "outputs": [
     {
@@ -971,7 +971,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74379b52",
+   "id": "4170c0bf",
    "metadata": {},
    "source": [
     "Brier Score is a distance in the probability domain. Which means: the lower the value of this score, the better the prediction."
@@ -979,7 +979,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b57b77ac",
+   "id": "f910ca22",
    "metadata": {},
    "source": [
     "The above calculated score is a harsh metric since we require for each sample that each label set be correctly predicted. This does not give us a clear indication of a better model so we will use the reliability diagram to find out the better suited model.\n",
@@ -989,7 +989,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b6206288",
+   "id": "719aab48",
    "metadata": {},
    "source": [
     "##### Reliability Diagram\n",
@@ -1002,7 +1002,7 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "b170674f",
+   "id": "a94959e7",
    "metadata": {},
    "outputs": [
     {
@@ -1033,7 +1033,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "840149c6",
+   "id": "74a9dd24",
    "metadata": {},
    "source": [
     "In the above graph, the solid line represents the calibration of the SVMs predicted probabilities and the dotted line represents a comparison to a perfectly calibrated model. The better calibrated or more reliable a forecast, the closer the points will appear along the main diagonal from the bottom left to the top right of the plot. Here, we see that calibration probabilities are much further away from the ideal prediction.\n",
@@ -1048,7 +1048,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a649923d",
+   "id": "46e1744e",
    "metadata": {},
    "source": [
     "#### Calibrated Classification Model\n",
@@ -1060,7 +1060,7 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "0dd52faf",
+   "id": "9ba588fc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1093,7 +1093,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1fa29d6d",
+   "id": "0ef3269a",
    "metadata": {},
    "source": [
     "*NOTE* : The probabilities are not normalized, but can be normalized when calling the `calibration_curve()` function by setting the `normalize` argument to `True`."
@@ -1102,7 +1102,7 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "7fcbe5ff",
+   "id": "0b9a663f",
    "metadata": {},
    "outputs": [
     {
@@ -1127,7 +1127,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "891d7f63",
+   "id": "cd89927e",
    "metadata": {},
    "source": [
     "Brier Score is a distance in the probability domain. Which means: the lower the value of this score, the better the prediction. "
@@ -1135,7 +1135,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cf87d73e",
+   "id": "47a4de4a",
    "metadata": {},
    "source": [
     "The above calculated score is a harsh metric since we require for each sample that each label set be correctly predicted. This does not give us a clear indication of a better model so we will use the reliability diagram to find out the better suited model."
@@ -1143,7 +1143,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c652d99",
+   "id": "51138c75",
    "metadata": {},
    "source": [
     "##### Reliability Diagram\n",
@@ -1155,7 +1155,7 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "f435c927",
+   "id": "45f042b0",
    "metadata": {},
    "outputs": [
     {
@@ -1186,7 +1186,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c27096f",
+   "id": "d341c4bf",
    "metadata": {},
    "source": [
     "Here, we see that the shape of the calibrated probabilities is different, hugging the diagonal line much better, although still under-forecasting and over-forecasting i.e. the solid line is both above and below the ideal model.\n",
@@ -1197,7 +1197,7 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "65647610",
+   "id": "b646e340",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1207,7 +1207,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4998d31e",
+   "id": "7406bb19",
    "metadata": {},
    "source": [
     "We now have the probabilities for each test likely to fail stored in the column `prob`."
@@ -1215,7 +1215,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a36445bb",
+   "id": "aae618f3",
    "metadata": {},
    "source": [
     "## Save results to Ceph or locally\n",
@@ -1225,7 +1225,7 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "62596a76",
+   "id": "fe192358",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-04-01T15:43:53.427951Z",
@@ -1254,7 +1254,7 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "90639f51",
+   "id": "2957126c",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-04-01T15:43:53.914079Z",
@@ -1451,7 +1451,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "019ca906",
+   "id": "24483935",
    "metadata": {},
    "source": [
     "## Conclusion : \n",

--- a/notebooks/data-sources/TestGrid/metrics/test_pass_failures.ipynb
+++ b/notebooks/data-sources/TestGrid/metrics/test_pass_failures.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "vocational-iraqi",
+   "id": "c2f9c2c3",
    "metadata": {},
    "source": [
     "# Quantify test pass/failures\n",
@@ -23,7 +23,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "enabling-election",
+   "id": "9802577e",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-04-01T15:41:55.449933Z",
@@ -65,7 +65,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "infectious-worst",
+   "id": "aced4d13",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-04-01T15:41:55.455115Z",
@@ -90,7 +90,7 @@
     "s3_access_key = os.getenv(\"S3_ACCESS_KEY\")\n",
     "s3_secret_key = os.getenv(\"S3_SECRET_KEY\")\n",
     "s3_bucket = os.getenv(\"S3_BUCKET\")\n",
-    "s3_path = os.getenv(\"S3_PROJECT_KEY\", \"metrics\")\n",
+    "s3_path = os.getenv(\"S3_PROJECT_KEY\", \"ai4ci/testgrid/metrics\")\n",
     "s3_input_data_path = \"raw_data\"\n",
     "\n",
     "# Specify whether or not we are running this as a notebook or part of an automation pipeline.\n",
@@ -100,7 +100,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "dramatic-hypothesis",
+   "id": "0ec5f72c",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-04-01T15:42:09.552625Z",
@@ -126,7 +126,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "associate-turkish",
+   "id": "f2afe72d",
    "metadata": {},
    "source": [
     "## Metric Calculation\n",
@@ -136,7 +136,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "dynamic-marks",
+   "id": "781dbcdb",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-04-01T15:42:33.307447Z",
@@ -151,7 +151,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "cross-reynolds",
+   "id": "4bbc41ee",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-04-01T15:42:33.314076Z",
@@ -177,7 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "lesbian-spanish",
+   "id": "420d20ea",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-04-01T15:42:46.458026Z",
@@ -197,7 +197,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "2e1bc107-372f-4031-80f4-f9e99298365a",
+   "id": "6779d9d5",
    "metadata": {},
    "outputs": [
     {
@@ -300,7 +300,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "tamil-opera",
+   "id": "2d03123b",
    "metadata": {},
    "source": [
     "We now find all the tests which are passing i.e. have a status code of 1"
@@ -309,7 +309,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "seventh-controversy",
+   "id": "46333ea3",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-04-01T15:43:09.974015Z",
@@ -324,7 +324,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "related-studio",
+   "id": "1608ab18",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-04-01T15:43:09.980705Z",
@@ -350,7 +350,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "wired-zealand",
+   "id": "4bc1517c",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-04-01T15:43:21.985721Z",
@@ -370,7 +370,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "399ce45c-3bb1-4671-a279-4a05e8a77534",
+   "id": "a1d94400",
    "metadata": {},
    "outputs": [
     {
@@ -474,7 +474,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "raising-pollution",
+   "id": "3b0ea648",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-04-01T15:43:48.354260Z",
@@ -601,7 +601,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "renewable-master",
+   "id": "712d1836",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-04-01T15:43:51.594251Z",
@@ -642,7 +642,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "combined-kingdom",
+   "id": "ba9d4560",
    "metadata": {},
    "source": [
     "## Save results to Ceph or locally\n",
@@ -652,7 +652,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "paperback-cookie",
+   "id": "c14d7e00",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-04-01T15:43:53.427951Z",
@@ -681,7 +681,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "accepted-silence",
+   "id": "bbce1a7f",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-04-01T15:43:53.914079Z",
@@ -889,7 +889,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "numerous-monkey",
+   "id": "f0935505",
    "metadata": {},
    "source": [
     "## Conclusion\n",

--- a/notebooks/data-sources/TestGrid/metrics/time_to_fail.ipynb
+++ b/notebooks/data-sources/TestGrid/metrics/time_to_fail.ipynb
@@ -75,7 +75,7 @@
     "s3_access_key = os.getenv(\"S3_ACCESS_KEY\")\n",
     "s3_secret_key = os.getenv(\"S3_SECRET_KEY\")\n",
     "s3_bucket = os.getenv(\"S3_BUCKET\")\n",
-    "s3_path = os.getenv(\"S3_PROJECT_KEY\", \"metrics\")\n",
+    "s3_path = os.getenv(\"S3_PROJECT_KEY\", \"ai4ci/testgrid/metrics\")\n",
     "s3_input_data_path = \"raw_data\"\n",
     "\n",
     "# Specify whether or not we are running this as a notebook or part of an automation pipeline.\n",

--- a/notebooks/data-sources/TestGrid/metrics/time_to_test.ipynb
+++ b/notebooks/data-sources/TestGrid/metrics/time_to_test.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "2226573d",
+   "id": "de328e4b",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-12T15:35:37.863850Z",
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fc4cbd83",
+   "id": "22ca1e05",
    "metadata": {},
    "source": [
     "_Linked issues: [issue1](https://github.com/aicoe-aiops/ocp-ci-analysis/issues/117)_"
@@ -31,7 +31,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "2cafc799",
+   "id": "a526f830",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-25T20:19:12.433862Z",
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e9d1b4d5",
+   "id": "e2a22570",
    "metadata": {},
    "source": [
     "For extracting this metric, we will dig into the time series data in the detailed test grids. In this notebook, we use the `Overall` tests as our proxy for builds."
@@ -77,7 +77,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f54730e8",
+   "id": "d1a2ee83",
    "metadata": {},
    "source": [
     "There are inbuilt Graphs within TestGrid for each Test in the job, which capture the time taken for running each test."
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "86064129",
+   "id": "511b6d7f",
    "metadata": {},
    "source": [
     "As a part of our data download and extraction process we are capturing time taken not for all tests but the test `Overall` which can be used as a proxy for a Build since time durations are not consistently captured for all tests. Thus in this notebook, we capture time elapsed for each Build."
@@ -94,7 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "031fac3a",
+   "id": "8bf05736",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +114,7 @@
     "s3_access_key = os.getenv(\"S3_ACCESS_KEY\")\n",
     "s3_secret_key = os.getenv(\"S3_SECRET_KEY\")\n",
     "s3_bucket = os.getenv(\"S3_BUCKET\")\n",
-    "s3_path = os.getenv(\"S3_PROJECT_KEY\", \"metrics\")\n",
+    "s3_path = os.getenv(\"S3_PROJECT_KEY\", \"ai4ci/testgrid/metrics\")\n",
     "s3_input_data_path = \"raw_data\"\n",
     "AUTOMATION = os.getenv(\"IN_AUTOMATION\")"
    ]
@@ -122,7 +122,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "f7aada58",
+   "id": "277eb9ac",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -143,7 +143,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "90fe8d4c",
+   "id": "64d6a952",
    "metadata": {},
    "source": [
     "## Metric Calculation\n",
@@ -153,7 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "06b7fbd8",
+   "id": "b501e24c",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-25T20:00:08.197830Z",
@@ -169,7 +169,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "3d410862",
+   "id": "31e7ab8a",
    "metadata": {},
    "outputs": [
     {
@@ -190,7 +190,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "793c6967",
+   "id": "ddf081e0",
    "metadata": {},
    "outputs": [
     {
@@ -215,7 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "df8c2bc4",
+   "id": "792bc0b9",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-25T20:00:20.628684Z",
@@ -328,7 +328,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "ff462d20",
+   "id": "25be3d3f",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-25T20:00:25.775781Z",
@@ -343,7 +343,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "cbed742a",
+   "id": "4cb92ae4",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-25T20:00:28.420797Z",
@@ -452,7 +452,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "da493dcb",
+   "id": "e835eb13",
    "metadata": {},
    "outputs": [
     {
@@ -472,7 +472,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d468f9ae",
+   "id": "a825b8ee",
    "metadata": {},
    "source": [
     "## Metric Calculation\n",
@@ -482,7 +482,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "5de3d852",
+   "id": "d9e78cb6",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-25T20:00:47.026572Z",
@@ -499,7 +499,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "bfb4ca5e",
+   "id": "801a05da",
    "metadata": {},
    "outputs": [
     {
@@ -603,7 +603,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "290289ed",
+   "id": "cb5f6f21",
    "metadata": {},
    "source": [
     "## Visualization\n",
@@ -613,7 +613,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "f1b9be3a",
+   "id": "d36ab787",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-25T20:01:57.643822Z",
@@ -634,7 +634,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "b9225f18",
+   "id": "04cd6180",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-25T20:02:43.411154Z",
@@ -764,7 +764,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "4fbee9ee",
+   "id": "58893779",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-25T20:14:14.543059Z",
@@ -797,7 +797,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "d9499292",
+   "id": "e8a363c7",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-03-25T20:15:16.721388Z",
@@ -826,7 +826,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "427123bc",
+   "id": "1d514c38",
    "metadata": {},
    "source": [
     "In the above graph, we see how the time taken to run a build changes over time and we notice when there are spikes or when irregular builds occur."
@@ -834,7 +834,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7884d0a9",
+   "id": "0f9d8366",
    "metadata": {},
    "source": [
     "## Save to Ceph or local"
@@ -843,7 +843,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "109e4544",
+   "id": "cfa6124a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -867,7 +867,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "862f34df",
+   "id": "314b8d1a",
    "metadata": {},
    "outputs": [
     {
@@ -1046,7 +1046,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ff98a8ae",
+   "id": "94e6db1e",
    "metadata": {},
    "source": [
     "### Conclusion\n",


### PR DESCRIPTION
## Related Issues and Dependencies

Metric paths in the metric calculation notebooks have been changed to reflect the metric path suggested in https://github.com/aicoe-aiops/ocp-ci-analysis/blob/master/docs/how-to-contribute.md#contribute-to-a-kpi-metric

The documentation was updated to let the parquet file in the metric path include the name of the metric as well to easily distinguish two types of metrics

## This introduces a breaking change

- [ ] Yes
- [x] No

## Related Issues

related https://github.com/aicoe-aiops/ocp-ci-analysis/issues/388