### PR TITLE
Updating the link to White Paper for AppSurify

### DIFF
--- a/docs/aiml-cicd-market-research.md
+++ b/docs/aiml-cicd-market-research.md
@@ -9,7 +9,8 @@ A curated list of companies involved in AI/ML for CI/CD.
 Links:
 
 *   [Website](https://appsurify.com/flaky-tests/)
-*   [White Paper explaining their ML model for detecting flaking tests](https://appsurify.com/wp-content/uploads/2019/12/TestBrain-Risk-Model.pdf)
+*   [White Paper explaining their ML model for detecting flaking tests](https://appsurify.com/wp-content/uploads/2021/06/TestBrainMachineLearningRiskAnalysis.pdf)
+*   [White Paper explaining their ML model to determine the likelihood of the test failing based on a particular change](https://appsurify.com/wp-content/uploads/2021/06/Appsurify-TestSelectionAppsurify-Whitepaper.pdf)
 
 ### BuildPulse.io
 


### PR DESCRIPTION
While going through the [README file](https://github.com/aicoe-aiops/ocp-ci-analysis/blob/master/docs/aiml-cicd-market-research.md) about the list of companies involved in AI/ML for CI/CD. I found that the link for white paper is outdated. In this PR, I have updated the link. 

## Related Issues and Dependencies

## This introduces a breaking change

- [ ] Yes
- [x] No

