### PR TITLE
Do not attempt to process logs from jobs that have not started

### DIFF
--- a/notebooks/data-sources/gcsweb-ci/build-logs/build_log_EDA.ipynb
+++ b/notebooks/data-sources/gcsweb-ci/build-logs/build_log_EDA.ipynb
@@ -188,6 +188,9 @@
     "            finished = json.loads(blob.download_as_bytes())\n",
     "\n",
     "            blob = self.bucket.get_blob(f\"{prefix}started.json\")\n",
+    "            if not blob:\n",
+    "                # Build has not started yet\n",
+    "                continue\n",
     "            started = json.loads(blob.download_as_bytes())\n",
     "\n",
     "            blob = self.bucket.get_blob(f\"{prefix}build-log.txt\")\n",
@@ -1094,7 +1097,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.9"
+   "version": "3.8.12"
   },
   "toc-autonumbering": true,
   "toc-showtags": false


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes #426

## This introduces a breaking change

No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Fix a bug when trying to download logs from prow jobs that have not yet started.

## Description

When fetching log data we collect 3 artifacts from each job: `started.json`, `finished.json` and the `build-log.txt` itself.

The code was checking the presence of  the last two, but not the first one (`started.json`). This adds this missing check.
