### PR TITLE
Thoth's runtime environment must not use colon in name

### DIFF
--- a/.thoth.yaml
+++ b/.thoth.yaml
@@ -3,7 +3,7 @@ tls_verify: false
 requirements_format: pipenv
 
 runtime_environments:
-  - name: rhel:8
+  - name: rhel-8
     operating_system:
       name: rhel
       version: "8"


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/integration-tests/issues/255

## This introduces a breaking change

- [x] No

## Description

Thoth's configuration does not allow colon in runtime environment name.
