### PR TITLE
Remove editable installation

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -32,7 +32,6 @@ trino = "*"
 scipy = "<1.6.1"
 intersect = "*"
 xgboost = "*"
-src = {path="."}
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1f476d49bcdbe2810f07a70bef0cd2e632f52dd283cc49467b9f3f735a4f3528"
+            "sha256": "e2fad60ddfc1a1638c202a8b8094e0292d4d334d612cf850674a8030481044f9"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1555,10 +1555,6 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==2.3.1"
-        },
-        "src": {
-            "path": ".",
-            "version": "==0.1.0"
         },
         "tangled-up-in-unicode": {
             "hashes": [


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## Description

Thoth cannot perform advice on editable installations. See also [the relevant article published about it](https://developers.redhat.com/articles/2021/05/26/can-we-consider-editable-bad-practice).

If you wish to make code available to the Python process, you can do so by putting it to PYTHONPATH:

```PYTHONPATH=src/```

Related: https://github.com/thoth-station/integration-tests/issues/255
