### PR TITLE
Update installation of src during s2i build to use https

### DIFF
--- a/models/github-ttm/requirements.txt
+++ b/models/github-ttm/requirements.txt
@@ -1,4 +1,4 @@
-git+git://github.com/aicoe-aiops/ocp-ci-analysis.git@master#egg=src
+git+https://github.com/aicoe-aiops/ocp-ci-analysis.git@master#egg=src
 boto3
 pyyaml
 requests


### PR DESCRIPTION
## Related Issues and Dependencies

None

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Updates the pip install of the `src` package during s2i build of github-ttm service to use `https` instead of `git`

## Description

According to official pip [docs](https://pip.pypa.io/en/stable/topics/vcs-support/), usage of `git+git` is deprecated, and `git+https` should be used instead. @suppathak and @oindrillac pointed out that the [requirements.txt](https://github.com/aicoe-aiops/ocp-ci-analysis/blob/a32074a4852999953f16419adaf5963052fb91bf/models/github-ttm/requirements.txt#L1) for the s2i build of the github-ttm seldon server is currently using `git+git`. This PR updates it to use `git+https` instead.