### PR TITLE
Rename output classes returned in github pr ttm prediction service

### DIFF
--- a/models/github-ttm/GitHubTTMModel.py
+++ b/models/github-ttm/GitHubTTMModel.py
@@ -50,7 +50,18 @@ class GitHubTTMModel(object):
 
     def class_names(self) -> Iterable[str]:
         """Return names of output classes."""
-        return [f"Class_{i}" for i in range(10)]
+        return [
+            "0 - 3 hrs",
+            "3 - 6 hrs",
+            "6 - 15 hrs",
+            "15 - 24 hrs",
+            "1 - 1.5 days",
+            "1.5 - 2.5 days",
+            "2.5 - 4.67 days",
+            "4.67 - 7.92 days",
+            "7.92 - 19.25 days",
+            ">19.25 days",
+        ]
 
     def transform_input(
         self, X: np.ndarray, names: Iterable[str], meta: Dict = None  # noqa: N803


### PR DESCRIPTION
## Related Issues and Dependencies

Closes #488 

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Updates names of the time interval classes that are returned to the user when they query the openshift origin ttm prediction service. The new names reflect the time intervals defined in the [model training notebook](https://github.com/aicoe-aiops/ocp-ci-analysis/blob/2bb9d41017a5a8055da2913c3e3fa1452419672a/notebooks/time-to-merge-prediction/openshift-origin/time_to_merge_model.ipynb).
