### PR TITLE
Fix failing imports in openshift origin TTM notebooks

### DIFF
--- a/notebooks/time-to-merge-prediction/openshift-origin/github_PR_log_models.ipynb
+++ b/notebooks/time-to-merge-prediction/openshift-origin/github_PR_log_models.ipynb
@@ -43,11 +43,11 @@
     "\n",
     "from dotenv import load_dotenv, find_dotenv\n",
     "\n",
-    "metric_template_path = \"../data-sources/TestGrid/metrics\"\n",
+    "metric_template_path = \"../../data-sources/TestGrid/metrics\"\n",
     "if metric_template_path not in sys.path:\n",
     "    sys.path.insert(1, metric_template_path)\n",
     "\n",
-    "metric_template_path = \"../data-sources/oc-github-repo/\"\n",
+    "metric_template_path = \"../../data-sources/oc-github-repo/\"\n",
     "if metric_template_path not in sys.path:\n",
     "    sys.path.insert(1, metric_template_path)\n",
     "\n",
@@ -1036,7 +1036,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/notebooks/time-to-merge-prediction/openshift-origin/model_inference.ipynb
+++ b/notebooks/time-to-merge-prediction/openshift-origin/model_inference.ipynb
@@ -41,7 +41,7 @@
     "\n",
     "from sklearn.metrics import classification_report\n",
     "\n",
-    "metric_template_path = \"../data-sources/TestGrid/metrics\"\n",
+    "metric_template_path = \"../../data-sources/TestGrid/metrics\"\n",
     "if metric_template_path not in sys.path:\n",
     "    sys.path.insert(1, metric_template_path)\n",
     "\n",
@@ -965,7 +965,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/notebooks/time-to-merge-prediction/openshift-origin/time_to_merge_model.ipynb
+++ b/notebooks/time-to-merge-prediction/openshift-origin/time_to_merge_model.ipynb
@@ -77,7 +77,7 @@
     "    TitleWordCountTransformer,\n",
     ")\n",
     "\n",
-    "metric_template_path = \"../data-sources/TestGrid/metrics\"\n",
+    "metric_template_path = \"../../data-sources/TestGrid/metrics\"\n",
     "if metric_template_path not in sys.path:\n",
     "    sys.path.insert(1, metric_template_path)\n",
     "\n",
@@ -1975,7 +1975,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Related Issues and Dependencies

None

## This introduces a breaking change

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

In a previous PR, the openshift-origin time-to-merge notebooks were moved from `notebooks/time-to-merge-prediction` to `notebooks/time-to-merge-prediction/openshift-origin`. However the path from where the util functions ([metric_template.ipynb](https://github.com/aicoe-aiops/ocp-ci-analysis/blob/7123d1ad528b0f70f3319e3ea42169928892fff5/notebooks/data-sources/TestGrid/metrics/metric_template.ipynb)) are imported in these notebooks was not updated. So these imports are failing currently. This is a small PR trying to fix that.