### PR TITLE
added parameter to pipeline

### DIFF
--- a/notebooks/time-to-merge-prediction/workshop/end-to-end.pipeline
+++ b/notebooks/time-to-merge-prediction/workshop/end-to-end.pipeline
@@ -23,7 +23,8 @@
                 "CEPH_BUCKET=aiops-tools-workshop-2",
                 "CEPH_BUCKET_PREFIX=",
                 "CEPH_KEY_ID=",
-                "CEPH_SECRET_KEY="
+                "CEPH_SECRET_KEY=",
+                "S3_ENDPOINT_URL=https://s3-rook-openshift-storage.apps.morty.emea.operate-first.cloud"
               ],
               "dependencies": [],
               "include_subdirectories": false,


### PR DESCRIPTION
Added `S3_ENDPOINT_URL` parameter to first step in pipeline.
This fixes errors seen in pipelines such as [this](https://ml-pipeline-ui-kubeflow.apps.smaug.na.operate-first.cloud/#/runs/details/d1bda243-4553-46c2-bff6-40e7c6438b21) 
After fix - https://ml-pipeline-ui-kubeflow.apps.smaug.na.operate-first.cloud/#/runs/details/4c1fe8d3-15ea-4b99-9d14-aabd663aa397