### PR TITLE
switch token order

### DIFF
--- a/.github/workflows/predict-ttm.yaml
+++ b/.github/workflows/predict-ttm.yaml
@@ -28,7 +28,7 @@ jobs:
           CEPH_BUCKET_PREFIX: ${{ github.event.client_payload.PREFIX|| secrets.CEPH_BUCKET_PREFIX }}
           CEPH_KEY_ID: ${{ github.event.client_payload.AWS_ACCESS_KEY_ID  || secrets.AWS_ACCESS_KEY_ID }}
           CEPH_SECRET_KEY: ${{ github.event.client_payload.AWS_SECRET_ACCESS_KEY || secrets.AWS_SECRET_ACCESS_KEY }}
-          GITHUB_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_ACCESS_TOKEN: ${{  secrets.GITHUB_TOKEN || secrets.ACCESS_TOKEN  }}
           # Setting mode by default as 0, this will only run inference mode and if defined as 1 will train and run inference.
           MODE: 0
           REMOTE: 1


### PR DESCRIPTION
Swapped token order in inference step to default to github's. This will make the PR comment come from the action instead of a user's account my default.  